### PR TITLE
Improve run-tests script

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -45,8 +45,17 @@ runner.RegisterTest(new FrozenSegmentTest());
 // Stress Tests
 runner.RegisterTest(new StressTest());
 
-// Run all tests
-var success = runner.RunAll();
+// Check if a specific test was requested via command-line argument
+bool success;
+if (args.Length > 0)
+{
+    success = runner.RunSingle(args[0]);
+}
+else
+{
+    // Run all tests
+    success = runner.RunAll();
+}
 
 // Return appropriate exit code
 return success ? 0 : 1;

--- a/TestApp/TestFramework/TestRunner.cs
+++ b/TestApp/TestFramework/TestRunner.cs
@@ -56,6 +56,36 @@ public class TestRunner
         return _failed == 0;
     }
 
+    public bool RunSingle(string testName)
+    {
+        AnsiConsole.Write(new Rule("[bold cyan]Test Execution[/]").RuleStyle("cyan").Centered());
+        AnsiConsole.WriteLine();
+
+        var test = _tests.FirstOrDefault(t => t.Name.Equals(testName, StringComparison.OrdinalIgnoreCase));
+
+        if (test == null)
+        {
+            AnsiConsole.MarkupLine($"[red]Test '{Markup.Escape(testName)}' not found.[/]");
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[yellow]Available tests:[/]");
+            foreach (var t in _tests)
+            {
+                AnsiConsole.MarkupLine($"  • {Markup.Escape(t.Name)}");
+            }
+            return false;
+        }
+
+        AnsiConsole.MarkupLine($"[dim]Running test: {Markup.Escape(test.Name)}...[/]");
+        AnsiConsole.WriteLine();
+
+        var result = RunTest(test);
+        
+        PrintResults([result]);
+        PrintSummary();
+
+        return _failed == 0;
+    }
+
     private TestResult RunTest(TestBase test)
     {
         try

--- a/run-tests.cmd
+++ b/run-tests.cmd
@@ -1,4 +1,33 @@
 @echo off
+setlocal enabledelayedexpansion
+
+REM Default values
+set CONFIG=Release
+set TEST_NAME=
+
+REM Parse command-line arguments
+:parse_args
+if "%~1"=="" goto end_parse_args
+if /i "%~1"=="--debug" (
+    set CONFIG=Debug
+    shift
+    goto parse_args
+)
+if /i "%~1"=="--test" (
+    set TEST_NAME=%~2
+    shift
+    shift
+    goto parse_args
+)
+echo Unknown argument: %~1
+echo.
+echo Usage: run-tests.cmd [--debug] [--test TEST_NAME]
+echo   --debug      Build TestApp in Debug configuration (default: Release)
+echo   --test NAME  Run only the specified test (case-insensitive)
+exit /b 1
+
+:end_parse_args
+
 echo ========================================
 echo Building and Publishing ManagedDotnetGC
 echo ========================================
@@ -14,11 +43,11 @@ if %ERRORLEVEL% NEQ 0 (
 
 echo.
 echo ========================================
-echo Building TestApp
+echo Building TestApp (Configuration: %CONFIG%)
 echo ========================================
 echo.
 
-dotnet build .\TestApp -c Release
+dotnet build .\TestApp -c %CONFIG%
 
 if %ERRORLEVEL% NEQ 0 (
     echo.
@@ -28,7 +57,7 @@ if %ERRORLEVEL% NEQ 0 (
 
 echo.
 echo Copying GC DLL to TestApp directory...
-copy .\ManagedDotnetGC\bin\Debug\net10.0\win-x64\publish\* .\TestApp\bin\Release\net10.0\win-x64\
+copy .\ManagedDotnetGC\bin\Debug\net10.0\win-x64\publish\* .\TestApp\bin\%CONFIG%\net10.0\win-x64\
 
 echo.
 echo ========================================
@@ -39,7 +68,15 @@ echo.
 @set DOTNET_GCName=ManagedDotnetGC.dll
 @set DOTNET_gcConservative=0
 
-.\TestApp\bin\Release\net10.0\win-x64\TestApp.exe
+if not "%TEST_NAME%"=="" (
+    echo Running single test: %TEST_NAME%
+    echo.
+    .\TestApp\bin\%CONFIG%\net10.0\win-x64\TestApp.exe "%TEST_NAME%"
+) else (
+    echo Running all tests
+    echo.
+    .\TestApp\bin\%CONFIG%\net10.0\win-x64\TestApp.exe
+)
 
 set TEST_EXIT_CODE=%ERRORLEVEL%
 


### PR DESCRIPTION
Enhanced `run-tests.cmd` to support `--test NAME` for running a single test and `--debug` for building in Debug mode, with improved argument parsing and usage instructions.