### PR TITLE
Remove support for fragmented address space

### DIFF
--- a/ManagedDotnetGC/GCHeap.Mark.cs
+++ b/ManagedDotnetGC/GCHeap.Mark.cs
@@ -91,7 +91,7 @@ unsafe partial class GCHeap
             return;
         }
 
-        if (_nativeAllocator.IsAddressRangeExclusive && !_nativeAllocator.IsInRange((IntPtr)obj))
+        if (!_nativeAllocator.IsInRange((IntPtr)obj))
         {
             return;
         }
@@ -138,7 +138,7 @@ unsafe partial class GCHeap
             var ptr = _markStack.Pop();
             var o = (GCObject*)ptr;
 
-            if (_nativeAllocator.IsAddressRangeExclusive && !_nativeAllocator.IsInRange(ptr))
+            if (!_nativeAllocator.IsInRange(ptr))
             {
                 continue;
             }

--- a/ManagedDotnetGC/GCHeap.Sweep.cs
+++ b/ManagedDotnetGC/GCHeap.Sweep.cs
@@ -9,7 +9,6 @@ unsafe partial class GCHeap
         Write("Updating weak references");
         ClearHandles();
         Sweep();
-        UnmarkFrozenSegments();
     }
 
     private void Sweep()
@@ -33,23 +32,6 @@ unsafe partial class GCHeap
 
                 // Allocate a free object to keep the heap walkable
                 AllocateFreeObject(ptr, (uint)(endPtr - startPtr - SizeOfObject));
-            }
-        }
-    }
-
-    private void UnmarkFrozenSegments()
-    {
-        if (_nativeAllocator.IsAddressRangeExclusive)
-        {
-            return;
-        }
-
-        foreach (var segment in _frozenSegments.Values)
-        {
-            foreach (var obj in WalkHeapObjects(segment.Value.start, segment.Value.end))
-            {
-                var o = (GCObject*)obj;
-                o->Unmark();
             }
         }
     }


### PR DESCRIPTION
Supporting allocations outside of the initial reserved memory range brings a lot of complications down the line even though it's mostly useless for modern 64-bit applications.