### PR TITLE
Add a feature-gated test suite for the missing-features inventory

### DIFF
--- a/ManagedDotnetGC.Api/GcApi.cs
+++ b/ManagedDotnetGC.Api/GcApi.cs
@@ -22,4 +22,14 @@ public class GcApi : IGc
     }
 
     public uint GetSyncBlockCacheCount() => _gc.GetSyncBlockCacheCount();
+
+    public nint GetContainingObject(nint address) => _gc.GetContainingObject(address);
+
+    public int IsHeapPointer(nint address) => _gc.IsHeapPointer(address);
+
+    public int IsPromoted(nint address) => _gc.IsPromoted(address);
+
+    public int GetGcCallbackCount(GcCallbackKind kind) => _gc.GetGcCallbackCount(kind);
+
+    public ulong GetWriteBarrierParameter(WriteBarrierParameterKind kind) => _gc.GetWriteBarrierParameter(kind);
 }

--- a/ManagedDotnetGC.Api/IGc.cs
+++ b/ManagedDotnetGC.Api/IGc.cs
@@ -1,7 +1,67 @@
-﻿namespace ManagedDotnetGC.Api;
+namespace ManagedDotnetGC.Api;
 
 [NativeObject]
 public interface IGc
 {
     uint GetSyncBlockCacheCount();
+
+    // Probes that route a test-provided address through the GC's own IGCHeap query
+    // implementations (docs/missing-features.md item 6.3). The tri-state queries return
+    // GcProbe.True/False, or a GcProbe sentinel when the underlying method is not implemented
+    // or threw. GetContainingObject returns the containing object's address, 0 when the address
+    // is not inside an object, or a GcProbe sentinel.
+    nint GetContainingObject(nint address);
+    int IsHeapPointer(nint address);
+    int IsPromoted(nint address);
+
+    // Number of times the GC issued the given EE bracket notification since startup
+    // (docs/missing-features.md item 2.1).
+    int GetGcCallbackCount(GcCallbackKind kind);
+
+    // Field of the WriteBarrierParameters passed to the EE on the most recent
+    // StompWriteBarrier call (docs/missing-features.md item 7.1).
+    ulong GetWriteBarrierParameter(WriteBarrierParameterKind kind);
+}
+
+/// <summary>
+/// Sentinel values returned by the <see cref="IGc"/> probe methods.
+/// </summary>
+public static class GcProbe
+{
+    /// <summary>The underlying IGCHeap method throws NotImplementedException.</summary>
+    public const int NotImplemented = -1;
+
+    /// <summary>The underlying IGCHeap method threw an unexpected exception (see the GC log).</summary>
+    public const int Error = -2;
+
+    public const int False = 0;
+    public const int True = 1;
+}
+
+/// <summary>
+/// The EE bracket notifications the GC must issue around a collection
+/// (docs/missing-features.md item 2.1).
+/// </summary>
+public enum GcCallbackKind
+{
+    GcStartWork,
+    BeforeGcScanRoots,
+    AfterGcScanRoots,
+    GcDone,
+
+    /// <summary>Number of times a bracket notification was issued out of order.</summary>
+    OrderViolation,
+}
+
+/// <summary>
+/// Fields of the WriteBarrierParameters struct passed to the EE (docs/missing-features.md item 7.1).
+/// </summary>
+public enum WriteBarrierParameterKind
+{
+    CardTable,
+    CardBundleTable,
+    LowestAddress,
+    HighestAddress,
+    EphemeralLow,
+    EphemeralHigh,
 }

--- a/ManagedDotnetGC/GCHeap.ManagedApi.cs
+++ b/ManagedDotnetGC/GCHeap.ManagedApi.cs
@@ -1,11 +1,24 @@
-﻿using ManagedDotnetGC.Api;
+using ManagedDotnetGC.Api;
 using static ManagedDotnetGC.Log;
 
 namespace ManagedDotnetGC;
 
-partial class GCHeap : IGc
+unsafe partial class GCHeap : IGc
 {
     private NativeObjects.IGc _managedApiObject;
+
+    // EE bracket notification counters, surfaced through IGc for GcCallbackBracketTest
+    // (docs/missing-features.md item 2.1)
+    private int _gcStartWorkCalls;
+    private int _beforeGcScanRootsCalls;
+    private int _afterGcScanRootsCalls;
+    private int _gcDoneCalls;
+    private int _bracketOrderViolations;
+    private int _bracketState; // 0 = idle, 1 = started, 2 = before root scan, 3 = after root scan
+
+    // The parameters passed to the EE on the most recent write barrier update, surfaced through
+    // IGc for WriteBarrierParamsTest (docs/missing-features.md item 7.1)
+    private WriteBarrierParameters _lastWriteBarrierParameters;
 
     private void InitializeManagedApi()
     {
@@ -21,5 +34,131 @@ partial class GCHeap : IGc
         _gcToClr.RestartEE(finishedGC: false);
 
         return count;
+    }
+
+    public nint GetContainingObject(nint address)
+    {
+        try
+        {
+            return (nint)GetContainingObject(address, fCollectedGenOnly: false);
+        }
+        catch (NotImplementedException)
+        {
+            return GcProbe.NotImplemented;
+        }
+        catch (Exception ex)
+        {
+            Write($"GetContainingObject probe threw: {ex.Message}");
+            return GcProbe.Error;
+        }
+    }
+
+    public int IsHeapPointer(nint address)
+    {
+        try
+        {
+            return IsHeapPointer(address, small_heap_only: false) ? GcProbe.True : GcProbe.False;
+        }
+        catch (NotImplementedException)
+        {
+            return GcProbe.NotImplemented;
+        }
+        catch (Exception ex)
+        {
+            Write($"IsHeapPointer probe threw: {ex.Message}");
+            return GcProbe.Error;
+        }
+    }
+
+    public int IsPromoted(nint address)
+    {
+        try
+        {
+            return IsPromoted((GCObject*)address) ? GcProbe.True : GcProbe.False;
+        }
+        catch (NotImplementedException)
+        {
+            return GcProbe.NotImplemented;
+        }
+        catch (Exception ex)
+        {
+            Write($"IsPromoted probe threw: {ex.Message}");
+            return GcProbe.Error;
+        }
+    }
+
+    public int GetGcCallbackCount(GcCallbackKind kind)
+    {
+        return kind switch
+        {
+            GcCallbackKind.GcStartWork => Volatile.Read(ref _gcStartWorkCalls),
+            GcCallbackKind.BeforeGcScanRoots => Volatile.Read(ref _beforeGcScanRootsCalls),
+            GcCallbackKind.AfterGcScanRoots => Volatile.Read(ref _afterGcScanRootsCalls),
+            GcCallbackKind.GcDone => Volatile.Read(ref _gcDoneCalls),
+            GcCallbackKind.OrderViolation => Volatile.Read(ref _bracketOrderViolations),
+            _ => GcProbe.Error
+        };
+    }
+
+    public ulong GetWriteBarrierParameter(WriteBarrierParameterKind kind)
+    {
+        var parameters = _lastWriteBarrierParameters;
+
+        return kind switch
+        {
+            WriteBarrierParameterKind.CardTable => (ulong)parameters.card_table,
+            WriteBarrierParameterKind.CardBundleTable => (ulong)parameters.card_bundle_table,
+            WriteBarrierParameterKind.LowestAddress => (ulong)parameters.lowest_address,
+            WriteBarrierParameterKind.HighestAddress => (ulong)parameters.highest_address,
+            WriteBarrierParameterKind.EphemeralLow => (ulong)parameters.ephemeral_low,
+            WriteBarrierParameterKind.EphemeralHigh => (ulong)parameters.ephemeral_high,
+            _ => ulong.MaxValue
+        };
+    }
+
+    // Records the parameters for GetWriteBarrierParameter. All write barrier updates sent to the
+    // EE must go through this wrapper rather than calling _gcToClr.StompWriteBarrier directly.
+    private void StompWriteBarrier(WriteBarrierParameters parameters)
+    {
+        _lastWriteBarrierParameters = parameters;
+        _gcToClr.StompWriteBarrier(&parameters);
+    }
+
+    // The sanctioned call sites for the EE bracket notifications (docs/missing-features.md
+    // item 2.1). When wiring them into the collection cycle, call these wrappers rather than
+    // _gcToClr directly, so that GcCallbackBracketTest can observe the calls and their ordering.
+    private void NotifyGcStartWork(int condemned, int maxGen)
+    {
+        RecordBracketCall(expectedState: 0, newState: 1, ref _gcStartWorkCalls);
+        _gcToClr.GcStartWork(condemned, maxGen);
+    }
+
+    private void NotifyBeforeGcScanRoots(int condemned, bool isBgc, bool isConcurrent)
+    {
+        RecordBracketCall(expectedState: 1, newState: 2, ref _beforeGcScanRootsCalls);
+        _gcToClr.BeforeGcScanRoots(condemned, isBgc, isConcurrent);
+    }
+
+    private void NotifyAfterGcScanRoots(int condemned, int maxGen, void* sc)
+    {
+        RecordBracketCall(expectedState: 2, newState: 3, ref _afterGcScanRootsCalls);
+        _gcToClr.AfterGcScanRoots(condemned, maxGen, sc);
+    }
+
+    private void NotifyGcDone(int condemned)
+    {
+        RecordBracketCall(expectedState: 3, newState: 0, ref _gcDoneCalls);
+        _gcToClr.GcDone(condemned);
+    }
+
+    private void RecordBracketCall(int expectedState, int newState, ref int counter)
+    {
+        if (_bracketState != expectedState)
+        {
+            Interlocked.Increment(ref _bracketOrderViolations);
+        }
+
+        _bracketState = newState;
+        Interlocked.Increment(ref counter);
     }
 }

--- a/ManagedDotnetGC/GCHeap.Mark.cs
+++ b/ManagedDotnetGC/GCHeap.Mark.cs
@@ -142,7 +142,9 @@ unsafe partial class GCHeap
 
             bool found = false;
 
-            foreach (var ptr in WalkHeapObjects(objectStartPtr, (IntPtr)root))
+            // The walk must include an object starting exactly at the interior pointer (the
+            // contract is obj <= ptr < obj + size) and WalkHeapObjects' end bound is exclusive
+            foreach (var ptr in WalkHeapObjects(objectStartPtr, (IntPtr)root + 1))
             {
                 var o = (GCObject*)ptr;
                 var size = o->ComputeSize();

--- a/ManagedDotnetGC/GCHeap.NotImplemented.cs
+++ b/ManagedDotnetGC/GCHeap.NotImplemented.cs
@@ -88,8 +88,11 @@ unsafe partial class GCHeap
 
     public uint WhichGeneration(GCObject* obj)
     {
-        Write("WhichGeneration");
-        throw new NotImplementedException();
+        // Non-generational: there is a single generation, 0. Objects outside the GC heap (frozen
+        // segments) report int.MaxValue, matching the stock GC. The answer for heap objects must
+        // never exceed GetMaxGeneration: the EE indexes arrays sized GetMaxGeneration + 1 with it
+        // (e.g. the dead-thread GC trigger heuristic in threads.cpp).
+        return _nativeAllocator.IsInRange((nint)obj) ? 0 : (uint)int.MaxValue;
     }
 
     public int StartNoGCRegion(ulong totalSize, bool lohSizeKnown, ulong lohSize, bool disallowFullBlockingGC)

--- a/ManagedDotnetGC/GCHeap.Stats.cs
+++ b/ManagedDotnetGC/GCHeap.Stats.cs
@@ -28,6 +28,9 @@ unsafe partial class GCHeap
         _gcInProgress = inProgress;
     }
 
+    // A single generation: WhichGeneration reports 0 for every heap object, and the pair must
+    // stay consistent (the EE indexes arrays sized GetMaxGeneration + 1 with WhichGeneration
+    // results, e.g. the dead-thread GC trigger heuristic in threads.cpp)
     public uint GetMaxGeneration() => 0;
 
     public int CollectionCount(int generation, int get_bgc_fgc_coutn) => (int)_gcCount;

--- a/ManagedDotnetGC/GCHeap.cs
+++ b/ManagedDotnetGC/GCHeap.cs
@@ -69,7 +69,7 @@ internal unsafe partial class GCHeap : Interfaces.IGCHeap
             ephemeral_low = -1
         };
 
-        _gcToClr.StompWriteBarrier(&parameters);
+        StompWriteBarrier(parameters);
 
         return HResult.S_OK;
     }

--- a/ManagedDotnetGC/ManagedDotnetGC.csproj
+++ b/ManagedDotnetGC/ManagedDotnetGC.csproj
@@ -34,7 +34,9 @@
         var lines = File.ReadAllLines(FilePath);
         for (int i = 0; i < lines.Length; i++)
         {
-            lines[i] = Regex.Replace(lines[i], @"_GC_(\w+)", "GC_$1=_GC_$1");
+            // Anchored so re-running on an already-transformed file is a no-op
+            // (a failed link would otherwise leave a def file that gets mangled on retry)
+            lines[i] = Regex.Replace(lines[i], @"^(\s*)_GC_(\w+)\s*$", "$1GC_$2=_GC_$2");
         }
         File.WriteAllLines(FilePath, lines);
         ]]>

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -1,7 +1,81 @@
+using ManagedDotnetGC.Api;
+using Spectre.Console;
 using TestApp.TestFramework;
 using TestApp.Tests;
 
-var runner = new TestRunner();
+// Child-process entry points must be handled before anything else (they run under special
+// runtime configurations, e.g. a tiny heap hard limit, and must avoid extra allocations).
+if (args.Length > 0 && args[0] == HeapHardLimitOomTest.ChildArgument)
+{
+    return HeapHardLimitOomTest.RunChild();
+}
+
+// Features not implemented yet in ManagedDotnetGC. Tests gated on them are skipped unless
+// explicitly requested with --feature <name> or --all-features. To start working on a feature,
+// remove it from this list and watch its tests fail.
+var pendingFeatures = new HashSet<GcFeature>
+{
+    GcFeature.CollectibleAssemblies,
+    GcFeature.RefCountedHandles,
+    GcFeature.FinalizationQueueRoots,
+    GcFeature.FrozenDependentHandles,
+    GcFeature.SuppressFinalizeDrop,
+    GcFeature.ApiSurface,
+    GcFeature.LatencyMode,
+    GcFeature.NoGCRegion,
+    GcFeature.EventCounters,
+    GcFeature.AllocationAccounting,
+    GcFeature.MemoryInfo,
+    GcFeature.GcTriggering,
+    GcFeature.MemoryReuse,
+    GcFeature.HardLimitOom,
+    GcFeature.GcEvents,
+    GcFeature.GcInternals,
+};
+
+string? singleTest = null;
+var featureFilter = new List<GcFeature>();
+bool allFeatures = false;
+
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--feature":
+            if (i + 1 >= args.Length)
+            {
+                return Usage("--feature requires a value");
+            }
+
+            foreach (var part in args[++i].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!Enum.TryParse<GcFeature>(part, ignoreCase: true, out var feature))
+                {
+                    return Usage($"Unknown feature '{part}'. Valid features: {string.Join(", ", Enum.GetNames<GcFeature>())}");
+                }
+
+                featureFilter.Add(feature);
+            }
+            break;
+
+        case "--all-features":
+            allFeatures = true;
+            break;
+
+        default:
+            if (args[i].StartsWith("--"))
+            {
+                return Usage($"Unknown argument '{args[i]}'");
+            }
+
+            singleTest = args[i];
+            break;
+    }
+}
+
+bool isCustomGcApiAvailable = GcApi.TryCreate() != null;
+
+var runner = new TestRunner(pendingFeatures, isCustomGcApiAvailable);
 
 runner.RegisterTest(new BasicAllocationTest());
 runner.RegisterTest(new LargeObjectTest());
@@ -13,6 +87,7 @@ runner.RegisterTest(new JaggedArrayTest());
 runner.RegisterTest(new ArrayOfStructsTest());
 runner.RegisterTest(new WeakReferenceTest());
 runner.RegisterTest(new InteriorPointerTest());
+runner.RegisterTest(new InteriorPointerObjectStartTest());
 runner.RegisterTest(new StaticRootTest());
 runner.RegisterTest(new ReferenceGraphTest());
 runner.RegisterTest(new CircularReferenceTest());
@@ -24,7 +99,9 @@ runner.RegisterTest(new StringTest());
 runner.RegisterTest(new NullReferenceTest());
 runner.RegisterTest(new GCHandleTest());
 runner.RegisterTest(new PinnedObjectTest());
+runner.RegisterTest(new PohPinnedAllocTest());
 runner.RegisterTest(new DependentHandleTest());
+runner.RegisterTest(new DependentHandleResurrectionTest());
 runner.RegisterTest(new FinalizerTest());
 runner.RegisterTest(new CriticalFinalizerTest());
 runner.RegisterTest(new FinalizerWeakReferenceTest());
@@ -35,7 +112,50 @@ runner.RegisterTest(new ConcurrentAllocationTest());
 runner.RegisterTest(new FrozenSegmentTest());
 runner.RegisterTest(new SyncBlockCacheTest());
 runner.RegisterTest(new StressTest());
+runner.RegisterTest(new GcTriggerTest());
+runner.RegisterTest(new MemoryFootprintTest());
+runner.RegisterTest(new HeapHardLimitOomTest());
+runner.RegisterTest(new GenerationApiTest());
+runner.RegisterTest(new LatencyModeTest());
+runner.RegisterTest(new NoGCRegionTest());
+runner.RegisterTest(new MiscGcApiTest());
+runner.RegisterTest(new EventCountersTest());
+runner.RegisterTest(new CollectibleAssemblyTest());
+runner.RegisterTest(new DynamicMethodTest());
+runner.RegisterTest(new ComWrappersTest());
+runner.RegisterTest(new PendingFinalizerRootsTest());
+runner.RegisterTest(new FrozenDependentHandleTest());
+runner.RegisterTest(new SuppressFinalizeSemanticsTest());
+runner.RegisterTest(new AllocationAccountingTest());
+runner.RegisterTest(new MemoryInfoTest());
+runner.RegisterTest(new GcInternalsProbeTest());
+runner.RegisterTest(new GcCallbackBracketTest());
+runner.RegisterTest(new WriteBarrierParamsTest());
 
-var success = args.Length > 0 ? runner.RunSingle(args[0]) : runner.RunAll();
+bool success;
+
+if (singleTest != null)
+{
+    success = runner.RunSingle(singleTest);
+}
+else if (featureFilter.Count > 0)
+{
+    success = runner.RunFeatures(featureFilter);
+}
+else
+{
+    success = runner.RunAll(includePendingFeatures: allFeatures);
+}
 
 return success ? 0 : 1;
+
+static int Usage(string error)
+{
+    AnsiConsole.MarkupLine($"[red]{Markup.Escape(error)}[/]");
+    AnsiConsole.WriteLine();
+    AnsiConsole.MarkupLine("Usage: TestApp.exe [[TestName]] [[--feature Name[[,Name...]]]] [[--all-features]]");
+    AnsiConsole.MarkupLine("  TestName        Run a single test by name (bypasses the pending-feature gate)");
+    AnsiConsole.MarkupLine("  --feature X     Run only the tests of feature X, even if pending");
+    AnsiConsole.MarkupLine("  --all-features  Run every test, including pending features");
+    return 1;
+}

--- a/TestApp/README.md
+++ b/TestApp/README.md
@@ -36,9 +36,9 @@ This script will:
 To add a new test:
 
 1. Create a new class in the `Tests/` directory
-2. Inherit from `TestBase`
-3. Implement the `Run()` method
-4. Register the test in `TestHarnessProgram.cs`
+2. Inherit from `TestBase` and declare the `GcFeature` the test exercises
+3. Implement the `Run()` method (throw with a descriptive message on failure)
+4. Register the test in `Program.cs`
 
 Example:
 
@@ -47,31 +47,41 @@ using TestApp.TestFramework;
 
 namespace TestApp.Tests;
 
-public class MyNewTest : TestBase
+public class MyNewTest() : TestBase("My Test Name", GcFeature.Marking)
 {
-    public MyNewTest()
-        : base("My Test Name", "Description of what this test does")
+    public override void Run()
     {
-    }
-
-    public override bool Run()
-    {
-        // Test implementation
-        // Return true if test passes, false otherwise
-        return true;
+        // Test implementation; throw to fail
     }
 }
 ```
 
-Then register it in `TestHarnessProgram.cs`:
+Then register it in `Program.cs`:
 
 ```csharp
 runner.RegisterTest(new MyNewTest());
 ```
 
+Tests that need the custom GC API (`ManagedDotnetGC.Api`) override `RequiresCustomGcApi => true`;
+they are reported as skipped when running on the stock GC.
+
+## Feature gating
+
+Every test declares a `GcFeature`. Features listed in `PendingFeatures` (top of `Program.cs`) are
+not implemented in ManagedDotnetGC yet: their tests are skipped by default so the suite stays green
+while features are developed. See `docs/test-plan.md` for the full workflow.
+
+- `TestApp.exe` — run everything except pending features (what CI does)
+- `TestApp.exe --feature CollectibleAssemblies` — run only that feature's tests, even if pending
+- `TestApp.exe --all-features` — run everything, including pending features
+- `TestApp.exe "Test Name"` — run a single test by name (bypasses the pending gate)
+
+`run-tests.cmd` forwards `--feature` and `--all-features`. To start working on a feature, remove its
+enum value from `PendingFeatures` and watch its tests fail until the feature is implemented.
+
 ## Exit Codes
 
-- `0` - All tests passed
+- `0` - All tests passed (skipped tests don't count as failures)
 - `1` - One or more tests failed
 
 ## Environment Variables

--- a/TestApp/TestFramework/ChildProcess.cs
+++ b/TestApp/TestFramework/ChildProcess.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+
+namespace TestApp.TestFramework;
+
+/// <summary>
+/// Relaunches the test executable as a child process. Used by tests that need environment
+/// variables set before runtime startup (e.g. DOTNET_GCHeapHardLimit) or that would take the whole
+/// process down on failure. The child inherits the current environment (including DOTNET_GCName,
+/// so it runs on the same GC as the parent) plus the provided overrides.
+/// </summary>
+public static class ChildProcess
+{
+    public sealed record Result(int ExitCode, string StdOut, string StdErr, bool TimedOut)
+    {
+        public string Describe() =>
+            TimedOut
+                ? $"timed out. Stdout: {StdOut} Stderr: {StdErr}"
+                : $"exited with code {ExitCode}. Stdout: {StdOut} Stderr: {StdErr}";
+    }
+
+    public static Result Run(string arguments, IReadOnlyDictionary<string, string> extraEnvironment, TimeSpan timeout)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Environment.ProcessPath!,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var (key, value) in extraEnvironment)
+        {
+            startInfo.Environment[key] = value;
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new Exception($"Failed to start child process {startInfo.FileName}");
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit((int)timeout.TotalMilliseconds))
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // The process may have exited in the meantime
+            }
+
+            process.WaitForExit();
+            return new Result(-1, SafeResult(stdout), SafeResult(stderr), TimedOut: true);
+        }
+
+        // WaitForExit(milliseconds) can return before the output streams are drained;
+        // the parameterless overload flushes them.
+        process.WaitForExit();
+
+        return new Result(process.ExitCode, SafeResult(stdout), SafeResult(stderr), TimedOut: false);
+
+        static string SafeResult(Task<string> task)
+        {
+            try
+            {
+                return task.GetAwaiter().GetResult().Trim();
+            }
+            catch (Exception ex)
+            {
+                return $"<failed to read: {ex.Message}>";
+            }
+        }
+    }
+}

--- a/TestApp/TestFramework/GcFeature.cs
+++ b/TestApp/TestFramework/GcFeature.cs
@@ -1,0 +1,43 @@
+namespace TestApp.TestFramework;
+
+/// <summary>
+/// The functional area a test exercises. Every test declares one.
+///
+/// Tests whose feature is listed in <c>Program.PendingFeatures</c> (not implemented yet in
+/// ManagedDotnetGC) are skipped by default and only run when explicitly requested with
+/// <c>--feature &lt;name&gt;</c> or <c>--all-features</c>. To start working on a feature, remove it
+/// from that list and watch its tests fail.
+/// </summary>
+public enum GcFeature
+{
+    // ── Implemented (existing coverage) ─────────────────────────────────────────────
+    Allocation,
+    Marking,
+    Stress,
+    InteriorPointers,
+    Handles,
+    WeakReferences,
+    DependentHandles,
+    Finalization,
+    FrozenSegments,
+    SyncBlocks,
+    GenerationApis,          // 6.2: GC.GetGeneration / GC.MaxGeneration (WhichGeneration, GetMaxGeneration)
+
+    // ── Pending (see docs/missing-features.md for the corresponding items) ──────────
+    CollectibleAssemblies,   // 3.1 + 4.1/4.2: LoaderAllocator edge, weak interior pointer handles
+    RefCountedHandles,       // 3.2: HNDTYPE_REFCOUNTED scanning/clearing + RefCountedHandleCallbacks
+    FinalizationQueueRoots,  // 3.3: f-reachable queue promoted early in the mark phase
+    FrozenDependentHandles,  // 3.4: frozen-segment objects as dependent-handle primary/secondary
+    SuppressFinalizeDrop,    // 5.1: suppressed dead objects dropped at scan, not resurrected
+    ApiSurface,              // 6.1: misc GC APIs (RefreshMemoryLimit, ...)
+    LatencyMode,             // 6.1: GCSettings.LatencyMode get/set
+    NoGCRegion,              // 6.1: GC.TryStartNoGCRegion / EndNoGCRegion
+    EventCounters,           // 6.1: GetGenerationBudget etc. polled by RuntimeEventSource
+    AllocationAccounting,    // 8.1: alloc_bytes bookkeeping (GetAllocatedBytesForCurrentThread)
+    MemoryInfo,              // 6.1/10: GetGCMemoryInfo / GetTotalMemory
+    GcTriggering,            // 1.1: allocation-triggered collections
+    MemoryReuse,             // 1.2: swept memory is reused / decommitted
+    HardLimitOom,            // 1.3: GCHeapHardLimit honored + null-on-OOM
+    GcEvents,                // 10: EventSink GC events (GCStart/GCEnd)
+    GcInternals,             // Category B probes via ManagedDotnetGC.Api (custom GC only)
+}

--- a/TestApp/TestFramework/TestBase.cs
+++ b/TestApp/TestFramework/TestBase.cs
@@ -7,10 +7,31 @@ public abstract class TestBase
 {
     public string Name { get; }
 
-    protected TestBase(string name)
+    /// <summary>
+    /// The functional area this test exercises. Used for feature-gating (pending features are
+    /// skipped unless explicitly requested) and for running a feature's tests with --feature.
+    /// </summary>
+    public GcFeature Feature { get; }
+
+    protected TestBase(string name, GcFeature feature)
     {
         Name = name;
+        Feature = feature;
     }
+
+    /// <summary>
+    /// True for tests that need the ManagedDotnetGC.Api channel and therefore can only run on the
+    /// custom GC. They are reported as skipped on the stock GC.
+    /// </summary>
+    public virtual bool RequiresCustomGcApi => false;
+
+    /// <summary>
+    /// Watchdog timeout for this test. Note: the in-process watchdog only catches hangs that leave
+    /// the EE running (deadlocked WaitForPendingFinalizers, runaway loops). A hang *inside* the GC
+    /// with the EE suspended also suspends the watchdog thread — only an external timeout (CI-level)
+    /// can catch those.
+    /// </summary>
+    public virtual int TimeoutSeconds => 120;
 
     /// <summary>
     /// Run the test. Throws an exception with a descriptive message if the test fails.

--- a/TestApp/TestFramework/TestRunner.cs
+++ b/TestApp/TestFramework/TestRunner.cs
@@ -3,28 +3,87 @@ using Spectre.Console;
 namespace TestApp.TestFramework;
 
 /// <summary>
-/// Test runner that executes all registered tests and reports results
+/// Test runner that executes registered tests and reports results.
+/// Tests can be skipped for two reasons: they require the custom GC API and the stock GC is
+/// running, or their feature is still pending (see Program.PendingFeatures) and wasn't explicitly
+/// requested.
 /// </summary>
 public class TestRunner
 {
     private readonly List<TestBase> _tests = new();
+    private readonly IReadOnlySet<GcFeature> _pendingFeatures;
+    private readonly bool _isCustomGcApiAvailable;
     private int _passed;
     private int _failed;
+    private int _skipped;
     private readonly List<(string testName, string error)> _failures = new();
 
-    private sealed record TestResult(string Name, bool Passed, Exception? Error);
+    private enum TestStatus { Passed, Failed, Skipped }
+
+    private sealed record TestResult(string Name, TestStatus Status, Exception? Error, string? SkipReason);
+
+    public TestRunner(IReadOnlySet<GcFeature> pendingFeatures, bool isCustomGcApiAvailable)
+    {
+        _pendingFeatures = pendingFeatures;
+        _isCustomGcApiAvailable = isCustomGcApiAvailable;
+    }
 
     public void RegisterTest(TestBase test)
     {
         _tests.Add(test);
     }
 
-    public bool RunAll()
+    public bool RunAll(bool includePendingFeatures)
+    {
+        return Execute(_tests, bypassFeatureGate: includePendingFeatures);
+    }
+
+    public bool RunFeatures(IReadOnlyCollection<GcFeature> features)
+    {
+        var selected = _tests.Where(t => features.Contains(t.Feature)).ToList();
+
+        if (selected.Count == 0)
+        {
+            AnsiConsole.MarkupLine($"[red]No tests found for feature(s): {Markup.Escape(string.Join(", ", features))}[/]");
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[yellow]Features with tests:[/]");
+            foreach (var group in _tests.GroupBy(t => t.Feature).OrderBy(g => g.Key.ToString()))
+            {
+                AnsiConsole.MarkupLine($"  • {group.Key} ({group.Count()} test(s))");
+            }
+            return false;
+        }
+
+        return Execute(selected, bypassFeatureGate: true);
+    }
+
+    public bool RunSingle(string testName)
+    {
+        var test = _tests.FirstOrDefault(t => t.Name.Equals(testName, StringComparison.OrdinalIgnoreCase));
+
+        if (test == null)
+        {
+            AnsiConsole.MarkupLine($"[red]Test '{Markup.Escape(testName)}' not found.[/]");
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[yellow]Available tests:[/]");
+            foreach (var t in _tests)
+            {
+                AnsiConsole.MarkupLine($"  • {Markup.Escape(t.Name)}");
+            }
+            return false;
+        }
+
+        // Running a test by name bypasses the pending-feature gate (that's the point of asking for
+        // it explicitly), but a test that needs the custom GC API still can't run on the stock GC.
+        return Execute([test], bypassFeatureGate: true);
+    }
+
+    private bool Execute(IReadOnlyList<TestBase> tests, bool bypassFeatureGate)
     {
         AnsiConsole.Write(new Rule("[bold cyan]Test Execution[/]").RuleStyle("cyan").Centered());
         AnsiConsole.WriteLine();
 
-        AnsiConsole.MarkupLine($"[dim]Running {_tests.Count} test(s)...[/]");
+        AnsiConsole.MarkupLine($"[dim]Running {tests.Count} test(s)...[/]");
         AnsiConsole.WriteLine();
 
         var results = new List<TestResult>();
@@ -41,11 +100,22 @@ public class TestRunner
             ])
             .Start(ctx =>
             {
-                var task = ctx.AddTask("[cyan]Executing tests[/]", maxValue: _tests.Count);
+                var task = ctx.AddTask("[cyan]Executing tests[/]", maxValue: tests.Count);
 
-                foreach (var test in _tests)
+                foreach (var test in tests)
                 {
-                    results.Add(RunTest(test));
+                    var skipReason = GetSkipReason(test, bypassFeatureGate);
+
+                    if (skipReason != null)
+                    {
+                        _skipped++;
+                        results.Add(new TestResult(test.Name, TestStatus.Skipped, null, skipReason));
+                    }
+                    else
+                    {
+                        results.Add(RunTest(test));
+                    }
+
                     task.Increment(1);
                 }
             });
@@ -56,54 +126,42 @@ public class TestRunner
         return _failed == 0;
     }
 
-    public bool RunSingle(string testName)
+    private string? GetSkipReason(TestBase test, bool bypassFeatureGate)
     {
-        AnsiConsole.Write(new Rule("[bold cyan]Test Execution[/]").RuleStyle("cyan").Centered());
-        AnsiConsole.WriteLine();
-
-        var test = _tests.FirstOrDefault(t => t.Name.Equals(testName, StringComparison.OrdinalIgnoreCase));
-
-        if (test == null)
+        if (test.RequiresCustomGcApi && !_isCustomGcApiAvailable)
         {
-            AnsiConsole.MarkupLine($"[red]Test '{Markup.Escape(testName)}' not found.[/]");
-            AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("[yellow]Available tests:[/]");
-            foreach (var t in _tests)
-            {
-                AnsiConsole.MarkupLine($"  • {Markup.Escape(t.Name)}");
-            }
-            return false;
+            return "requires the ManagedDotnetGC API (custom GC only)";
         }
 
-        AnsiConsole.MarkupLine($"[dim]Running test: {Markup.Escape(test.Name)}...[/]");
-        AnsiConsole.WriteLine();
+        if (!bypassFeatureGate && _pendingFeatures.Contains(test.Feature))
+        {
+            return $"feature {test.Feature} not implemented yet (--feature {test.Feature} to run)";
+        }
 
-        var result = RunTest(test);
-        
-        PrintResults([result]);
-        PrintSummary();
-
-        return _failed == 0;
+        return null;
     }
 
     private TestResult RunTest(TestBase test)
     {
         try
         {
+            Watchdog.Arm(test.Name, test.TimeoutSeconds);
+
             test.Setup();
             test.Run();
 
             _passed++;
-            return new TestResult(test.Name, true, null);
+            return new TestResult(test.Name, TestStatus.Passed, null, null);
         }
         catch (Exception ex)
         {
             _failed++;
             _failures.Add((test.Name, ex.ToString()));
-            return new TestResult(test.Name, false, ex);
+            return new TestResult(test.Name, TestStatus.Failed, ex, null);
         }
         finally
         {
+            Watchdog.Disarm();
             test.Cleanup();
         }
     }
@@ -120,8 +178,13 @@ public class TestRunner
 
         foreach (var result in results)
         {
-            var status = result.Passed ? "[green]Passed[/]" : "[red]Failed[/]";
-            var details = result.Passed ? string.Empty : $"[red]{Markup.Escape(result.Error?.Message ?? "Failed")}[/]";
+            var (status, details) = result.Status switch
+            {
+                TestStatus.Passed => ("[green]Passed[/]", string.Empty),
+                TestStatus.Skipped => ("[yellow]Skipped[/]", $"[dim]{Markup.Escape(result.SkipReason ?? "")}[/]"),
+                _ => ("[red]Failed[/]", $"[red]{Markup.Escape(result.Error?.Message ?? "Failed")}[/]")
+            };
+
             table.AddRow(Markup.Escape(result.Name), status, details);
         }
 
@@ -134,12 +197,17 @@ public class TestRunner
         AnsiConsole.MarkupLine("[bold]Test Summary[/]");
         AnsiConsole.WriteLine();
 
-        var totalTests = _passed + _failed;
+        var totalTests = _passed + _failed + _skipped;
         AnsiConsole.MarkupLine($"Total:  {totalTests}");
 
         if (_passed != 0)
         {
             AnsiConsole.MarkupLine($"[green]Passed: {_passed}[/]");
+        }
+
+        if (_skipped != 0)
+        {
+            AnsiConsole.MarkupLine($"[yellow]Skipped: {_skipped}[/]");
         }
 
         if (_failed != 0)
@@ -159,5 +227,49 @@ public class TestRunner
         }
 
         AnsiConsole.MarkupLine("[bold cyan]═══════════════════════════════════════════════════[/]");
+    }
+
+    /// <summary>
+    /// Fails fast with the offending test's name when a test exceeds its timeout, so CI shows which
+    /// test hung instead of a silent zombie process. Limitation: this is a managed thread — a hang
+    /// inside the GC with the EE suspended also suspends the watchdog. Those hangs can only be
+    /// caught by an external (out-of-process) timeout.
+    /// </summary>
+    private static class Watchdog
+    {
+        private static Thread? _thread;
+        private static string? _testName;
+        private static long _deadline; // Environment.TickCount64-based; 0 = disarmed
+
+        public static void Arm(string testName, int timeoutSeconds)
+        {
+            _testName = testName;
+            Volatile.Write(ref _deadline, Environment.TickCount64 + timeoutSeconds * 1000L);
+
+            if (_thread == null)
+            {
+                _thread = new Thread(Loop) { IsBackground = true, Name = "TestWatchdog" };
+                _thread.Start();
+            }
+        }
+
+        public static void Disarm() => Volatile.Write(ref _deadline, 0);
+
+        private static void Loop()
+        {
+            while (true)
+            {
+                Thread.Sleep(1000);
+
+                var deadline = Volatile.Read(ref _deadline);
+
+                if (deadline != 0 && Environment.TickCount64 > deadline)
+                {
+                    var message = $"WATCHDOG: test '{_testName}' exceeded its timeout";
+                    Console.Error.WriteLine(message);
+                    Environment.FailFast(message);
+                }
+            }
+        }
     }
 }

--- a/TestApp/Tests/AllocationAccountingTest.cs
+++ b/TestApp/Tests/AllocationAccountingTest.cs
@@ -1,0 +1,121 @@
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests allocation-byte accounting: GC.GetAllocatedBytesForCurrentThread must be non-negative and
+/// grow with allocations (it goes negative when the GC hands out allocation-context windows without
+/// maintaining alloc_bytes), GC.GetTotalAllocatedBytes must be monotonic, and GC.GetTotalMemory
+/// must reflect live data. (docs/missing-features.md items 8.1, 6.1)
+/// </summary>
+public class AllocationAccountingTest() : TestBase("Allocation Accounting", GcFeature.AllocationAccounting)
+{
+    private const long ChurnBytes = 10L * 1024 * 1024;
+
+    public override void Run()
+    {
+        TestPerThreadAllocatedBytes();
+        TestTotalAllocatedBytes();
+        TestTotalMemory();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestPerThreadAllocatedBytes()
+    {
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        if (before < 0)
+        {
+            throw new Exception($"GC.GetAllocatedBytesForCurrentThread returned a negative value: {before}");
+        }
+
+        AllocateChurn();
+
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        if (after < 0)
+        {
+            throw new Exception($"GC.GetAllocatedBytesForCurrentThread returned a negative value after allocating: {after}");
+        }
+
+        if (after - before < ChurnBytes)
+        {
+            throw new Exception(
+                $"GC.GetAllocatedBytesForCurrentThread grew by {after - before} bytes after allocating {ChurnBytes} bytes");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestTotalAllocatedBytes()
+    {
+        long before = GC.GetTotalAllocatedBytes(precise: true);
+
+        AllocateChurn();
+
+        long after = GC.GetTotalAllocatedBytes(precise: true);
+
+        if (after < before)
+        {
+            throw new Exception($"GC.GetTotalAllocatedBytes went backwards: {before} -> {after}");
+        }
+
+        if (after - before < ChurnBytes)
+        {
+            throw new Exception(
+                $"GC.GetTotalAllocatedBytes grew by {after - before} bytes after allocating {ChurnBytes} bytes");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestTotalMemory()
+    {
+        long withLive = HoldLiveDataAndMeasure(out var liveData);
+
+        if (withLive < ChurnBytes)
+        {
+            throw new Exception(
+                $"GC.GetTotalMemory(false) returned {withLive} while at least {ChurnBytes} bytes are live");
+        }
+
+        GC.KeepAlive(liveData);
+        liveData = null;
+
+        long afterRelease = GC.GetTotalMemory(forceFullCollection: true);
+
+        if (afterRelease < 0)
+        {
+            throw new Exception($"GC.GetTotalMemory(true) returned a negative value: {afterRelease}");
+        }
+
+        if (withLive - afterRelease < ChurnBytes / 2)
+        {
+            throw new Exception(
+                $"GC.GetTotalMemory did not decrease after releasing {ChurnBytes} bytes of live data " +
+                $"({withLive} -> {afterRelease})");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long HoldLiveDataAndMeasure(out List<byte[]> liveData)
+    {
+        liveData = new List<byte[]>();
+
+        for (int i = 0; i < ChurnBytes / (64 * 1024); i++)
+        {
+            liveData.Add(new byte[64 * 1024]);
+        }
+
+        return GC.GetTotalMemory(forceFullCollection: false);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocateChurn()
+    {
+        for (int i = 0; i < ChurnBytes / (64 * 1024); i++)
+        {
+            var array = new byte[64 * 1024];
+            array[0] = (byte)i;
+        }
+    }
+}

--- a/TestApp/Tests/ArrayOfStructsTest.cs
+++ b/TestApp/Tests/ArrayOfStructsTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests arrays of value types vs reference types
 /// </summary>
-public class ArrayOfStructsTest() : TestBase("Arrays of Structs")
+public class ArrayOfStructsTest() : TestBase("Arrays of Structs", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/ArrayVariantTest.cs
+++ b/TestApp/Tests/ArrayVariantTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests various array types and sizes
 /// </summary>
-public class ArrayVariantTest() : TestBase("Array Variants")
+public class ArrayVariantTest() : TestBase("Array Variants", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/BasicAllocationTest.cs
+++ b/TestApp/Tests/BasicAllocationTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests basic object allocation and memory initialization
 /// </summary>
-public class BasicAllocationTest() : TestBase("Basic Allocation")
+public class BasicAllocationTest() : TestBase("Basic Allocation", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/BoxingTest.cs
+++ b/TestApp/Tests/BoxingTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests boxing and unboxing of value types
 /// </summary>
-public class BoxingTest() : TestBase("Boxing/Unboxing")
+public class BoxingTest() : TestBase("Boxing/Unboxing", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/CircularReferenceTest.cs
+++ b/TestApp/Tests/CircularReferenceTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests that circular references are collected when no external root exists
 /// </summary>
-public class CircularReferenceTest() : TestBase("Circular References")
+public class CircularReferenceTest() : TestBase("Circular References", GcFeature.Marking)
 {
     public override void Run()
     {

--- a/TestApp/Tests/CollectibleAssemblyTest.cs
+++ b/TestApp/Tests/CollectibleAssemblyTest.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests collectible assemblies (AssemblyBuilderAccess.RunAndCollect): instances of collectible
+/// types must keep their LoaderAllocator (and thus their MethodTable and code) alive — this is the
+/// mark-phase LoaderAllocator edge. Statics of collectible types must work (they are tracked with
+/// HNDTYPE_WEAK_INTERIOR_POINTER handles), and the assembly must become collectible once nothing
+/// references it anymore. (docs/missing-features.md items 3.1, 4.1, 4.2)
+/// </summary>
+public class CollectibleAssemblyTest() : TestBase("Collectible Assemblies", GcFeature.CollectibleAssemblies)
+{
+    public override void Run()
+    {
+        TestInstanceKeepsTypeAlive();
+        TestCollectibleStatics();
+        TestAssemblyUnloads();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestInstanceKeepsTypeAlive()
+    {
+        object instance = CreateCollectibleInstance("KeepAliveAsm");
+
+        for (int i = 0; i < 3; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            // Both calls dereference the (collectible) MethodTable: if the LoaderAllocator was
+            // collected while the instance is alive, this reads freed memory.
+            var type = instance.GetType();
+
+            if (type.Name != "CollectibleType")
+            {
+                throw new Exception($"Unexpected type name: {type.Name}");
+            }
+
+            int value = (int)type.GetMethod("GetValue")!.Invoke(instance, null)!;
+
+            if (value != 42)
+            {
+                throw new Exception($"Method on collectible type returned {value}, expected 42");
+            }
+        }
+
+        GC.KeepAlive(instance);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestCollectibleStatics()
+    {
+        // The FieldInfo keeps the collectible assembly alive for the duration of this sub-test.
+        // Any strong reference to the stored value is scoped to NoInlining helpers so tier-0 stack
+        // slots in this frame can't extend its lifetime.
+        var field = CreateCollectibleInstance("StaticsAsm").GetType().GetField("StaticField")!;
+
+        var weakValue = SetStatic(field);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        // The static must root its value across collections
+        if (!weakValue.IsAlive)
+        {
+            throw new Exception("Value stored in a collectible static was collected");
+        }
+
+        VerifyReadBack(field, weakValue);
+
+        // Clearing the static must release the value
+        field.SetValue(null, null);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (weakValue.IsAlive)
+        {
+            throw new Exception("Value was not collected after the collectible static was cleared");
+        }
+
+        GC.KeepAlive(field);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference SetStatic(FieldInfo field)
+    {
+        var value = new object();
+        field.SetValue(null, value);
+        return new WeakReference(value);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void VerifyReadBack(FieldInfo field, WeakReference weakValue)
+    {
+        var readBack = field.GetValue(null);
+
+        if (!ReferenceEquals(readBack, weakValue.Target))
+        {
+            throw new Exception("Collectible static did not round-trip the stored reference");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestAssemblyUnloads()
+    {
+        var weakType = CreateAndDrop();
+
+        // Unloading a collectible assembly can take several collections
+        for (int i = 0; i < 10 && weakType.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        if (weakType.IsAlive)
+        {
+            throw new Exception("Collectible assembly did not unload after 10 collections");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateAndDrop()
+    {
+        var instance = CreateCollectibleInstance("UnloadAsm");
+        return new WeakReference(instance.GetType());
+    }
+
+    private static object CreateCollectibleInstance(string assemblyName)
+    {
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName(assemblyName), AssemblyBuilderAccess.RunAndCollect);
+
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("M");
+        var typeBuilder = moduleBuilder.DefineType("CollectibleType", TypeAttributes.Public);
+
+        var method = typeBuilder.DefineMethod("GetValue", MethodAttributes.Public, typeof(int), Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldc_I4, 42);
+        il.Emit(OpCodes.Ret);
+
+        typeBuilder.DefineField("StaticField", typeof(object), FieldAttributes.Public | FieldAttributes.Static);
+
+        var type = typeBuilder.CreateType();
+
+        return Activator.CreateInstance(type)!;
+    }
+}

--- a/TestApp/Tests/ComWrappersTest.cs
+++ b/TestApp/Tests/ComWrappersTest.cs
@@ -1,0 +1,85 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests ref-counted handle semantics through ComWrappers: a managed object exposed to native code
+/// (CCW) must stay alive while the native side holds a reference — even with no managed roots —
+/// and become collectable once the native reference is released. This exercises
+/// HNDTYPE_REFCOUNTED scanning (RefCountedHandleCallbacks) and its long-weak clearing.
+/// (docs/missing-features.md item 3.2)
+/// </summary>
+public class ComWrappersTest() : TestBase("ComWrappers Lifetime", GcFeature.RefCountedHandles)
+{
+    public override void Run()
+    {
+        var wrappers = new TestComWrappers();
+
+        var (ccw, weakObject) = CreateObjectWithCcw(wrappers);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        // No managed reference exists, but the native side still holds the CCW:
+        // the ref-counted handle must keep the object alive.
+        if (!weakObject.IsAlive)
+        {
+            throw new Exception("Managed object with a native-referenced CCW was collected");
+        }
+
+        VerifyUnwrap(wrappers, ccw, weakObject);
+
+        // Release the native reference: the object must now be collectable
+        Marshal.Release(ccw);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (weakObject.IsAlive)
+        {
+            throw new Exception("Managed object survived after its last native CCW reference was released");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (nint Ccw, WeakReference WeakObject) CreateObjectWithCcw(TestComWrappers wrappers)
+    {
+        var obj = new object();
+
+        nint ccw = wrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.None);
+
+        return (ccw, new WeakReference(obj));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void VerifyUnwrap(TestComWrappers wrappers, nint ccw, WeakReference weakObject)
+    {
+        // While rooted, unwrapping the CCW must return the original instance
+        var roundtrip = wrappers.GetOrCreateObjectForComInstance(ccw, CreateObjectFlags.Unwrap);
+
+        if (!ReferenceEquals(roundtrip, weakObject.Target))
+        {
+            throw new Exception("Unwrapping the CCW did not return the original managed object");
+        }
+    }
+
+    private sealed class TestComWrappers : ComWrappers
+    {
+        protected override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
+        {
+            // No custom interfaces: the CCW only exposes IUnknown, which is all lifetime tests need
+            count = 0;
+            return null;
+        }
+
+        protected override object CreateObject(nint externalComObject, CreateObjectFlags flags)
+            => throw new NotSupportedException();
+
+        protected override void ReleaseObjects(System.Collections.IEnumerable objects)
+            => throw new NotSupportedException();
+    }
+}

--- a/TestApp/Tests/ConcurrentAllocationTest.cs
+++ b/TestApp/Tests/ConcurrentAllocationTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests allocation from multiple threads (if threading is supported)
 /// </summary>
-public class ConcurrentAllocationTest() : TestBase("Concurrent Allocation")
+public class ConcurrentAllocationTest() : TestBase("Concurrent Allocation", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/CriticalFinalizerTest.cs
+++ b/TestApp/Tests/CriticalFinalizerTest.cs
@@ -9,7 +9,7 @@ namespace TestApp.Tests;
 /// The CLR guarantees that critical finalizers run after all regular finalizers
 /// for the same GC cycle.
 /// </summary>
-public class CriticalFinalizerTest() : TestBase("Critical Finalizers")
+public class CriticalFinalizerTest() : TestBase("Critical Finalizers", GcFeature.Finalization)
 {
     private static int _criticalFinalizerCount;
     private static int _regularFinalizerCount;

--- a/TestApp/Tests/DeepCallStackTest.cs
+++ b/TestApp/Tests/DeepCallStackTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests that GC correctly scans deep call stacks
 /// </summary>
-public class DeepCallStackTest() : TestBase("Deep Call Stack")
+public class DeepCallStackTest() : TestBase("Deep Call Stack", GcFeature.Marking)
 {
     public override void Run()
     {

--- a/TestApp/Tests/DependentHandleResurrectionTest.cs
+++ b/TestApp/Tests/DependentHandleResurrectionTest.cs
@@ -1,0 +1,86 @@
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests the interaction between dependent handles and finalization: while the primary awaits
+/// finalization (it was resurrected into the f-reachable queue), the secondary must stay alive —
+/// this requires the dependent-handle scan to run again after the finalization scan.
+///
+/// Note that the secondary is promoted as part of the resurrection wave, which happens *after*
+/// short weak references are severed: short weak references to both the primary and the secondary
+/// are cleared in that same GC, and only trackResurrection weak references observe the objects
+/// while the primary sits in the finalization queue. (Validated against the stock GC.)
+/// </summary>
+public class DependentHandleResurrectionTest() : TestBase("DependentHandle Resurrection", GcFeature.DependentHandles)
+{
+    private class Finalizable
+    {
+        ~Finalizable()
+        {
+        }
+    }
+
+    public override void Run()
+    {
+        var (handle, shortPrimary, longPrimary, longSecondary) = Create();
+
+        try
+        {
+            GC.Collect();
+
+            // The primary is now pending finalization. A short weak reference to it must have been
+            // cleared (severed before the finalization scan)...
+            if (shortPrimary.IsAlive)
+            {
+                throw new Exception("Short weak reference to a pending-finalization primary should have been cleared");
+            }
+
+            // ...but a trackResurrection weak reference tracks it through the finalization queue...
+            if (!longPrimary.IsAlive)
+            {
+                throw new Exception("Long weak reference to a pending-finalization primary should still be alive");
+            }
+
+            // ...and the dependent secondary is kept alive by the resurrected primary.
+            if (!longSecondary.IsAlive)
+            {
+                throw new Exception("Dependent secondary died while its primary was awaiting finalization");
+            }
+
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            // The primary has been finalized and collected: the secondary must die with it.
+            if (longPrimary.IsAlive)
+            {
+                throw new Exception("Primary survived after being finalized");
+            }
+
+            if (longSecondary.IsAlive)
+            {
+                throw new Exception("Dependent secondary survived after its primary was finalized and collected");
+            }
+        }
+        finally
+        {
+            handle.Dispose();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (DependentHandle Handle, WeakReference ShortPrimary, WeakReference LongPrimary, WeakReference LongSecondary) Create()
+    {
+        var primary = new Finalizable();
+        var secondary = new object();
+
+        var handle = new DependentHandle(primary, secondary);
+
+        return (handle,
+            new WeakReference(primary),
+            new WeakReference(primary, trackResurrection: true),
+            new WeakReference(secondary, trackResurrection: true));
+    }
+}

--- a/TestApp/Tests/DependentHandleTest.cs
+++ b/TestApp/Tests/DependentHandleTest.cs
@@ -8,7 +8,7 @@ namespace TestApp.Tests;
 /// Tests DependentHandle behavior - the dependent object is kept alive
 /// only as long as the target object is alive.
 /// </summary>
-public class DependentHandleTest() : TestBase("DependentHandle")
+public class DependentHandleTest() : TestBase("DependentHandle", GcFeature.DependentHandles)
 {
     public override void Run()
     {

--- a/TestApp/Tests/DynamicMethodTest.cs
+++ b/TestApp/Tests/DynamicMethodTest.cs
@@ -1,0 +1,67 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests lightweight code generation (DynamicMethod): the delegate must keep the underlying code
+/// alive across collections after the DynamicMethod object itself is dropped (collectible-code
+/// liveness), and everything must become collectible once the delegate is gone.
+/// (docs/missing-features.md item 3.1)
+/// </summary>
+public class DynamicMethodTest() : TestBase("Dynamic Methods", GcFeature.CollectibleAssemblies)
+{
+    public override void Run()
+    {
+        // All strong references to the delegate stay inside the helper so tier-0 stack slots in
+        // this frame can't extend its lifetime.
+        var weakDelegate = CreateUseAndDrop();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (weakDelegate.IsAlive)
+        {
+            throw new Exception("Dynamic method delegate was not collected after being dropped");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateUseAndDrop()
+    {
+        var del = BuildDelegate();
+
+        for (int i = 0; i < 3; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            int result = del(2, 3);
+
+            if (result != 5)
+            {
+                throw new Exception($"Dynamic method returned {result}, expected 5");
+            }
+        }
+
+        return new WeakReference(del);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Func<int, int, int> BuildDelegate()
+    {
+        var dynamicMethod = new DynamicMethod("Add", typeof(int), [typeof(int), typeof(int)]);
+
+        var il = dynamicMethod.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        // The DynamicMethod object is dropped when this method returns;
+        // only the delegate keeps the code alive
+        return dynamicMethod.CreateDelegate<Func<int, int, int>>();
+    }
+}

--- a/TestApp/Tests/EmptyObjectTest.cs
+++ b/TestApp/Tests/EmptyObjectTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests allocation of objects with no fields
 /// </summary>
-public class EmptyObjectTest() : TestBase("Empty Objects")
+public class EmptyObjectTest() : TestBase("Empty Objects", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/EventCountersTest.cs
+++ b/TestApp/Tests/EventCountersTest.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests that the process survives an EventCounters consumer — the in-process equivalent of
+/// attaching dotnet-counters. The System.Runtime counters poll GC APIs on a timer; in particular
+/// "gen-0-gc-budget" calls GC.GetGenerationBudget(0), which fail-fasts the custom GC as long as
+/// that method throws. The test asserts that counter payloads actually arrive, including the
+/// gen-0-gc-budget one. (docs/missing-features.md item 6.1)
+/// </summary>
+public class EventCountersTest() : TestBase("Event Counters", GcFeature.EventCounters)
+{
+    public override void Run()
+    {
+        using var listener = new CounterListener();
+
+        if (!listener.WaitForCounter("gen-0-gc-budget", TimeSpan.FromSeconds(15)))
+        {
+            throw new Exception(
+                $"No gen-0-gc-budget counter payload arrived within 15 seconds. " +
+                $"Counters seen: {string.Join(", ", listener.SeenCounters)}");
+        }
+    }
+
+    private sealed class CounterListener : EventListener
+    {
+        private readonly ConcurrentDictionary<string, byte> _seenCounters = new();
+        private readonly ManualResetEventSlim _signal = new(false);
+        private volatile string? _awaitedCounter;
+
+        public IReadOnlyCollection<string> SeenCounters => _seenCounters.Keys.ToArray();
+
+        public bool WaitForCounter(string name, TimeSpan timeout)
+        {
+            _awaitedCounter = name;
+
+            if (_seenCounters.ContainsKey(name))
+            {
+                return true;
+            }
+
+            return _signal.Wait(timeout);
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == "System.Runtime")
+            {
+                EnableEvents(eventSource, EventLevel.Informational, EventKeywords.None,
+                    new Dictionary<string, string?> { ["EventCounterIntervalSec"] = "1" });
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName != "EventCounters" || eventData.Payload is not { Count: > 0 })
+            {
+                return;
+            }
+
+            if (eventData.Payload[0] is IDictionary<string, object> payload
+                && payload.TryGetValue("Name", out var nameValue)
+                && nameValue is string name)
+            {
+                _seenCounters.TryAdd(name, 0);
+
+                if (name == _awaitedCounter)
+                {
+                    _signal.Set();
+                }
+            }
+        }
+    }
+}

--- a/TestApp/Tests/FinalizerTest.cs
+++ b/TestApp/Tests/FinalizerTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests that finalizers are called correctly for collected objects
 /// </summary>
-public class FinalizerTest() : TestBase("Finalizers")
+public class FinalizerTest() : TestBase("Finalizers", GcFeature.Finalization)
 {
     private static int _finalizerCallCount;
     private static int _suppressedFinalizerCallCount;

--- a/TestApp/Tests/FinalizerWeakReferenceTest.cs
+++ b/TestApp/Tests/FinalizerWeakReferenceTest.cs
@@ -17,7 +17,7 @@ namespace TestApp.Tests;
 ///   A finalizer can store a new strong reference to 'this', preventing collection.
 ///   A long weak reference created before resurrection remains valid after the finalizer runs.
 /// </summary>
-public class FinalizerWeakReferenceTest() : TestBase("Finalizer Weak References")
+public class FinalizerWeakReferenceTest() : TestBase("Finalizer Weak References", GcFeature.Finalization)
 {
     private static int _finalizerCallCount;
     private static ResurrectableObject? _resurrectedInstance;

--- a/TestApp/Tests/FragmentationTest.cs
+++ b/TestApp/Tests/FragmentationTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests GC behavior under fragmentation scenarios
 /// </summary>
-public class FragmentationTest() : TestBase("Fragmentation Handling")
+public class FragmentationTest() : TestBase("Fragmentation Handling", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/FrozenDependentHandleTest.cs
+++ b/TestApp/Tests/FrozenDependentHandleTest.cs
@@ -1,0 +1,147 @@
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests dependent handles whose primary or secondary lives outside the normal GC heap (frozen
+/// segments — string literals since .NET 8). The rule, validated against the stock GC: anything
+/// outside the GC heap counts as always-alive for dependent-handle purposes. A frozen primary must
+/// keep its secondary alive forever; a frozen secondary must neither hang the collection nor
+/// corrupt the handle. (docs/missing-features.md item 3.4 — note the livelock failure mode: on a
+/// broken GC this test hangs *inside* the GC, which only an external timeout can catch.)
+/// </summary>
+public class FrozenDependentHandleTest() : TestBase("Frozen Dependent Handles", GcFeature.FrozenDependentHandles)
+{
+    private const string FrozenPrimary = "FrozenDependentHandleTest primary literal";
+    private const string FrozenSecondary = "FrozenDependentHandleTest secondary literal";
+    private const string FrozenCwtKey = "FrozenDependentHandleTest cwt key literal";
+
+    public override void Run()
+    {
+        TestFrozenPrimaryKeepsSecondaryAlive();
+        TestFrozenSecondaryWithLivePrimary();
+        TestFrozenSecondaryWithDeadPrimary();
+        TestConditionalWeakTableWithLiteralKey();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestFrozenPrimaryKeepsSecondaryAlive()
+    {
+        var (handle, weakSecondary) = CreateWithFrozenPrimary();
+
+        try
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            // The literal primary is immortal, so the secondary must be too
+            if (!weakSecondary.IsAlive)
+            {
+                throw new Exception("Secondary of a frozen-primary dependent handle was collected");
+            }
+
+            if (!ReferenceEquals(handle.Dependent, weakSecondary.Target))
+            {
+                throw new Exception("Dependent handle no longer returns the stored secondary");
+            }
+        }
+        finally
+        {
+            handle.Dispose();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (DependentHandle Handle, WeakReference WeakSecondary) CreateWithFrozenPrimary()
+    {
+        var secondary = new object();
+        return (new DependentHandle(FrozenPrimary, secondary), new WeakReference(secondary));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestFrozenSecondaryWithLivePrimary()
+    {
+        var primary = new object();
+        var handle = new DependentHandle(primary, FrozenSecondary);
+
+        try
+        {
+            // On a GC that treats "not marked" as "needs promotion" without a heap-range check,
+            // a frozen secondary makes the dependent-handle fixpoint spin forever: this call hangs.
+            GC.Collect();
+
+            if (!ReferenceEquals(handle.Dependent, FrozenSecondary))
+            {
+                throw new Exception("Frozen secondary was dropped from the dependent handle while its primary is alive");
+            }
+
+            GC.KeepAlive(primary);
+        }
+        finally
+        {
+            handle.Dispose();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestFrozenSecondaryWithDeadPrimary()
+    {
+        var handle = CreateWithDeadPrimary();
+
+        try
+        {
+            GC.Collect();
+
+            // The primary is dead: the handle must be cleared, frozen secondary notwithstanding
+            if (handle.Target != null)
+            {
+                throw new Exception("Dependent handle with a dead primary still reports a target");
+            }
+        }
+        finally
+        {
+            handle.Dispose();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static DependentHandle CreateWithDeadPrimary()
+    {
+        return new DependentHandle(new object(), FrozenSecondary);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestConditionalWeakTableWithLiteralKey()
+    {
+        var table = new ConditionalWeakTable<string, object>();
+
+        var weakValue = AddValue(table);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (!weakValue.IsAlive)
+        {
+            throw new Exception("ConditionalWeakTable value keyed on a string literal was collected");
+        }
+
+        if (!table.TryGetValue(FrozenCwtKey, out var value) || !ReferenceEquals(value, weakValue.Target))
+        {
+            throw new Exception("ConditionalWeakTable lost the entry keyed on a string literal");
+        }
+
+        GC.KeepAlive(table);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference AddValue(ConditionalWeakTable<string, object> table)
+    {
+        var value = new object();
+        table.Add(FrozenCwtKey, value);
+        return new WeakReference(value);
+    }
+}

--- a/TestApp/Tests/FrozenSegmentTest.cs
+++ b/TestApp/Tests/FrozenSegmentTest.cs
@@ -9,7 +9,7 @@ namespace TestApp.Tests;
 /// Tests frozen segments by registering a frozen segment via GC._RegisterFrozenSegment,
 /// allocating objects in it, running a GC, and verifying the objects and their method tables remain intact.
 /// </summary>
-public class FrozenSegmentTest() : TestBase("Frozen Segments")
+public class FrozenSegmentTest() : TestBase("Frozen Segments", GcFeature.FrozenSegments)
 {
     public override unsafe void Run()
     {

--- a/TestApp/Tests/GCHandleTest.cs
+++ b/TestApp/Tests/GCHandleTest.cs
@@ -7,7 +7,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests different GCHandle types - verifies Strong, Weak, and Normal GCHandle behavior
 /// </summary>
-public class GCHandleTest() : TestBase("GCHandle Types")
+public class GCHandleTest() : TestBase("GCHandle Types", GcFeature.Handles)
 {
     public override void Run()
     {

--- a/TestApp/Tests/GcCallbackBracketTest.cs
+++ b/TestApp/Tests/GcCallbackBracketTest.cs
@@ -1,0 +1,65 @@
+using ManagedDotnetGC.Api;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Verifies that the GC issues the EE bracket notifications (GcStartWork, BeforeGcScanRoots,
+/// AfterGcScanRoots, GcDone) exactly once per collection and in the right order, using counters
+/// recorded by the GC itself. Self-instrumentation: it proves the calls happen, not that the EE
+/// liked them — the EE-observable side is covered by ComWrappersTest.
+/// (docs/missing-features.md item 2.1)
+/// </summary>
+public class GcCallbackBracketTest() : TestBase("GC Callback Brackets", GcFeature.GcInternals)
+{
+    public override bool RequiresCustomGcApi => true;
+
+    public override void Run()
+    {
+        var gc = GcApi.TryCreate() ?? throw new Exception("Failed to initialize GC API");
+
+        var baseline = Snapshot(gc);
+
+        const int collections = 3;
+
+        for (int i = 0; i < collections; i++)
+        {
+            GC.Collect();
+        }
+
+        var after = Snapshot(gc);
+
+        foreach (var kind in new[] { GcCallbackKind.GcStartWork, GcCallbackKind.BeforeGcScanRoots, GcCallbackKind.AfterGcScanRoots, GcCallbackKind.GcDone })
+        {
+            var delta = after[(int)kind] - baseline[(int)kind];
+
+            if (delta != collections)
+            {
+                throw new Exception(
+                    $"{kind} was issued {delta} times across {collections} collections, expected exactly {collections} " +
+                    "(the EE bracket notifications must be wired into the collection cycle)");
+            }
+        }
+
+        var violations = after[(int)GcCallbackKind.OrderViolation] - baseline[(int)GcCallbackKind.OrderViolation];
+
+        if (violations != 0)
+        {
+            throw new Exception(
+                $"{violations} bracket notification(s) were issued out of order " +
+                "(expected GcStartWork -> BeforeGcScanRoots -> AfterGcScanRoots -> GcDone)");
+        }
+    }
+
+    private static int[] Snapshot(GcApi gc)
+    {
+        var counts = new int[(int)GcCallbackKind.OrderViolation + 1];
+
+        for (int i = 0; i < counts.Length; i++)
+        {
+            counts[i] = gc.GetGcCallbackCount((GcCallbackKind)i);
+        }
+
+        return counts;
+    }
+}

--- a/TestApp/Tests/GcInternalsProbeTest.cs
+++ b/TestApp/Tests/GcInternalsProbeTest.cs
@@ -1,0 +1,129 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using ManagedDotnetGC.Api;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Routes test-provided addresses through the GC's own IGCHeap query implementations
+/// (GetContainingObject, IsHeapPointer, IsPromoted) via the managed API — a unit test of the
+/// brick-table interior-pointer resolution, which becomes correctness-critical once memory reuse
+/// lands and bricks can go stale.
+/// (docs/missing-features.md item 6.3)
+/// </summary>
+public class GcInternalsProbeTest() : TestBase("GC Internals Probes", GcFeature.GcInternals)
+{
+    public override bool RequiresCustomGcApi => true;
+
+    public override void Run()
+    {
+        var gc = GcApi.TryCreate() ?? throw new Exception("Failed to initialize GC API");
+
+        // Pin the array so its address stays valid for the duration of the probes
+        var array = new byte[4096];
+        var handle = GCHandle.Alloc(array, GCHandleType.Pinned);
+
+        try
+        {
+            nint objectStart = Utils.GetAddress(array);
+            nint dataStart = handle.AddrOfPinnedObject();
+
+            TestGetContainingObject(gc, objectStart, dataStart, array.Length);
+            TestIsHeapPointer(gc, objectStart);
+            TestIsPromoted(gc, objectStart);
+        }
+        finally
+        {
+            handle.Free();
+        }
+    }
+
+    private static void TestGetContainingObject(GcApi gc, nint objectStart, nint dataStart, int length)
+    {
+        // An interior pointer into the middle of the array must resolve to the object start
+        AssertContainingObject(gc, dataStart + length / 2, objectStart, "the middle of the array");
+
+        // Same for the first data byte...
+        AssertContainingObject(gc, dataStart, objectStart, "the first data byte");
+
+        // ...and for the very first byte of the object (the method table slot): stock find_object
+        // resolves obj <= ptr < obj + size, so a pointer at the object start belongs to that object
+        AssertContainingObject(gc, objectStart, objectStart, "the first byte of the object");
+
+        // One past the end of the object (byte[] on x64: 16-byte header + data, already aligned)
+        // is NOT inside it — it resolves to the next object or to nothing, never back to this one
+        var onePastEnd = CheckProbeSentinels(gc.GetContainingObject(dataStart + length), "one past the end of the object");
+
+        if (onePastEnd == objectStart)
+        {
+            throw new Exception("GetContainingObject(one past the end of the object) resolved back into the object");
+        }
+
+        // A stack address is not in the GC heap
+        AssertContainingObject(gc, GetStackAddress(), 0, "a stack address");
+
+        // Neither is null
+        AssertContainingObject(gc, 0, 0, "null");
+    }
+
+    private static void TestIsHeapPointer(GcApi gc, nint objectStart)
+    {
+        AssertTriState(gc.IsHeapPointer(objectStart), true, "IsHeapPointer", "a heap object address");
+        AssertTriState(gc.IsHeapPointer(GetStackAddress()), false, "IsHeapPointer", "a stack address");
+        AssertTriState(gc.IsHeapPointer(0), false, "IsHeapPointer", "null");
+    }
+
+    private static void TestIsPromoted(GcApi gc, nint objectStart)
+    {
+        // The EE only consults IsPromoted mid-collection (ComWrappers/RCW detach during the
+        // AfterGcScanRoots callback) and treats false as "dead, safe to detach" — so outside of a
+        // collection the only safe answer is true. Stock's own answer outside a GC is stale mark
+        // state; this asserts the safe contract, not observed stock behavior.
+        AssertTriState(gc.IsPromoted(objectStart), true, "IsPromoted", "a heap object address outside a GC");
+    }
+
+    private static void AssertContainingObject(GcApi gc, nint address, nint expected, string description)
+    {
+        var actual = CheckProbeSentinels(gc.GetContainingObject(address), $"GetContainingObject({description})");
+
+        if (actual != expected)
+        {
+            throw new Exception($"GetContainingObject({description}) returned {actual:x}, expected {expected:x}");
+        }
+    }
+
+    private static void AssertTriState(int actual, bool expected, string method, string description)
+    {
+        CheckProbeSentinels(actual, $"{method}({description})");
+
+        var expectedValue = expected ? GcProbe.True : GcProbe.False;
+
+        if (actual != expectedValue)
+        {
+            throw new Exception($"{method}({description}) returned {actual}, expected {expectedValue}");
+        }
+    }
+
+    private static nint CheckProbeSentinels(nint result, string description)
+    {
+        if (result == GcProbe.NotImplemented)
+        {
+            throw new Exception($"{description}: the underlying IGCHeap method is not implemented");
+        }
+
+        if (result == GcProbe.Error)
+        {
+            throw new Exception($"{description}: the underlying IGCHeap method threw (see the GC log)");
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static unsafe nint GetStackAddress()
+    {
+        int local = 0;
+        return (nint)(&local);
+    }
+}

--- a/TestApp/Tests/GcTriggerTest.cs
+++ b/TestApp/Tests/GcTriggerTest.cs
@@ -1,0 +1,45 @@
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests that the GC triggers collections on its own when the allocation budget is exhausted,
+/// without anyone calling GC.Collect. This is the core requirement for running arbitrary
+/// applications for an arbitrary amount of time: an app that never induces a collection must still
+/// be collected. (docs/missing-features.md item 1.1)
+/// </summary>
+public class GcTriggerTest() : TestBase("GC Trigger Policy", GcFeature.GcTriggering)
+{
+    public override void Run()
+    {
+        // Settle so pending work doesn't pollute the counters
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        int before = GC.CollectionCount(0);
+
+        AllocateChurn();
+
+        int after = GC.CollectionCount(0);
+
+        if (after <= before)
+        {
+            throw new Exception(
+                $"Allocating 256 MB did not trigger any collection (gen0 count stayed at {before}). " +
+                "The GC must collect on its own when the allocation budget is exhausted.");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocateChurn()
+    {
+        // 4096 x 64 KB = 256 MB of immediately-dropped small-object-heap allocations.
+        // 64 KB stays below the 85000-byte LOH threshold on the stock GC.
+        for (int i = 0; i < 4096; i++)
+        {
+            var array = new byte[64 * 1024];
+            array[0] = (byte)i;
+        }
+    }
+}

--- a/TestApp/Tests/GenerationApiTest.cs
+++ b/TestApp/Tests/GenerationApiTest.cs
@@ -1,0 +1,99 @@
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests the generation-numbering APIs. The custom GC is non-generational and reports a single
+/// generation (MaxGeneration = 0); the stock GC reports 2. What actually matters is consistency,
+/// which is what this test pins: GetGeneration never exceeds MaxGeneration (the EE indexes arrays
+/// sized MaxGeneration + 1 with per-object generations), survivors converge to MaxGeneration,
+/// frozen-segment objects report int.MaxValue, and per-generation collection counts increase
+/// monotonically.
+/// (docs/missing-features.md items 6.1/6.2)
+/// </summary>
+public class GenerationApiTest() : TestBase("Generation APIs", GcFeature.GenerationApis)
+{
+    public override void Run()
+    {
+        TestMaxGeneration();
+        TestObjectGeneration();
+        TestFrozenObjectGeneration();
+        TestCollectionCounts();
+    }
+
+    private static void TestMaxGeneration()
+    {
+        // 2 on the stock GC, 0 on the non-generational custom GC. Diagnostics assume at most
+        // three generations (GCMemoryInfo/EventCounters report gen0/1/2), hence the upper bound.
+        if (GC.MaxGeneration < 0 || GC.MaxGeneration > 2)
+        {
+            throw new Exception($"GC.MaxGeneration should be within [0, 2], got {GC.MaxGeneration}");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestObjectGeneration()
+    {
+        var obj = new object();
+
+        int generation = GC.GetGeneration(obj);
+
+        if (generation < 0 || generation > GC.MaxGeneration)
+        {
+            throw new Exception($"GC.GetGeneration returned {generation} for a fresh object, expected [0, {GC.MaxGeneration}]");
+        }
+
+        // A surviving object must end up reported as MaxGeneration after enough full collections
+        GC.Collect();
+        GC.Collect();
+
+        generation = GC.GetGeneration(obj);
+
+        if (generation != GC.MaxGeneration)
+        {
+            throw new Exception($"GC.GetGeneration returned {generation} for an object that survived two full collections, expected {GC.MaxGeneration}");
+        }
+
+        GC.KeepAlive(obj);
+    }
+
+    private static void TestFrozenObjectGeneration()
+    {
+        // String literals live on the frozen object heap since .NET 8; the GC reports non-heap
+        // objects as int.MaxValue (validated against the stock GC).
+        int generation = GC.GetGeneration("GenerationApiTest frozen literal");
+
+        if (generation != int.MaxValue)
+        {
+            throw new Exception($"GC.GetGeneration returned {generation} for a frozen string literal, expected int.MaxValue");
+        }
+    }
+
+    private static void TestCollectionCounts()
+    {
+        var before = new int[GC.MaxGeneration + 1];
+
+        for (int gen = 0; gen <= GC.MaxGeneration; gen++)
+        {
+            before[gen] = GC.CollectionCount(gen);
+
+            if (before[gen] < 0)
+            {
+                throw new Exception($"GC.CollectionCount({gen}) returned a negative value: {before[gen]}");
+            }
+        }
+
+        GC.Collect();
+
+        for (int gen = 0; gen <= GC.MaxGeneration; gen++)
+        {
+            int after = GC.CollectionCount(gen);
+
+            if (after <= before[gen])
+            {
+                throw new Exception($"GC.CollectionCount({gen}) did not increase after a full collection ({before[gen]} -> {after})");
+            }
+        }
+    }
+}

--- a/TestApp/Tests/HeapHardLimitOomTest.cs
+++ b/TestApp/Tests/HeapHardLimitOomTest.cs
@@ -1,0 +1,77 @@
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests OOM handling: with DOTNET_GCHeapHardLimit=128MB (must be set before runtime startup, hence
+/// the child process), exhausting the heap must surface as a catchable OutOfMemoryException — not a
+/// fail-fast — and the heap must remain usable afterwards. This requires the GC to honor the hard
+/// limit and to return null from Alloc on failure so the EE can throw the managed exception.
+/// (docs/missing-features.md item 1.3)
+/// </summary>
+public class HeapHardLimitOomTest() : TestBase("Hard Limit OOM", GcFeature.HardLimitOom)
+{
+    public const string ChildArgument = "--oom-child";
+
+    private const int ChildSuccessExitCode = 42;
+    private const string HardLimitHex = "8000000"; // DOTNET_ numeric configs are hexadecimal: 0x8000000 = 128 MB
+
+    public override void Run()
+    {
+        var result = ChildProcess.Run(
+            ChildArgument,
+            new Dictionary<string, string> { ["DOTNET_GCHeapHardLimit"] = HardLimitHex },
+            TimeSpan.FromSeconds(60));
+
+        if (result.ExitCode != ChildSuccessExitCode)
+        {
+            throw new Exception($"OOM child process {result.Describe()}");
+        }
+    }
+
+    /// <summary>
+    /// Child-process entry point, dispatched from Program.cs when the first argument is
+    /// <see cref="ChildArgument"/>. Runs with the 128 MB hard limit already applied.
+    /// </summary>
+    public static int RunChild()
+    {
+        try
+        {
+            var chunks = new List<byte[]>();
+
+            // Try to allocate 4 GB; with a 128 MB hard limit this must fail long before the end.
+            for (int i = 0; i < 4096; i++)
+            {
+                try
+                {
+                    chunks.Add(new byte[1024 * 1024]);
+                }
+                catch (OutOfMemoryException)
+                {
+                    // The exception was catchable (no fail-fast). Now verify the heap still works.
+                    chunks.Clear();
+                    chunks = null!;
+
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+
+                    var recovery = new byte[1024];
+                    recovery[0] = 1;
+                    GC.KeepAlive(recovery);
+
+                    Console.WriteLine($"Caught OutOfMemoryException after {i} MB and recovered");
+                    return ChildSuccessExitCode;
+                }
+            }
+
+            Console.Error.WriteLine("Allocated 4 GB without OutOfMemoryException - the hard limit was not honored");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"OOM child failed unexpectedly: {ex}");
+            return 2;
+        }
+    }
+}

--- a/TestApp/Tests/InteriorPointerObjectStartTest.cs
+++ b/TestApp/Tests/InteriorPointerObjectStartTest.cs
@@ -1,0 +1,55 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// An interior pointer may land on any byte of an object, including the very first one (the
+/// method-table word): the stock GC resolves GC_CALL_INTERIOR roots anywhere from the first byte
+/// of the object up to (but excluding) one past the end. ScanRoots currently drops that edge:
+/// FindClosestObjectBelow returns the object itself, and WalkHeapObjects(closestBelow, root) walks
+/// an empty range because of its exclusive upper bound, so the object is never marked. This test
+/// keeps an array alive through such a pointer alone.
+/// </summary>
+public class InteriorPointerObjectStartTest() : TestBase("Interior pointer at object start", GcFeature.InteriorPointers)
+{
+    // byte[] layout on x64: 8-byte method table pointer, 4-byte length, 4 bytes of padding
+    private const int ArrayDataOffset = 16;
+
+    public override void Run()
+    {
+        // Control: a pointer to the first data byte must keep the array alive — validates the
+        // mechanics of the test itself
+        RunScenario(offsetFromObjectStart: ArrayDataOffset, "the first data byte");
+
+        // The edge case: a pointer at the very first byte of the object
+        RunScenario(offsetFromObjectStart: 0, "the first byte of the object");
+    }
+
+    private static void RunScenario(int offsetFromObjectStart, string description)
+    {
+        ref byte interiorPointer = ref CreateArray(offsetFromObjectStart, out var weakRef);
+
+        GC.Collect();
+
+        if (!weakRef.IsAlive)
+        {
+            throw new Exception($"Array not alive when an interior pointer at {description} is held on stack");
+        }
+
+        GC.KeepAlive(interiorPointer);
+    }
+
+    // The array reference must not outlive this frame: the byref returned to the caller is its only root
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ref byte CreateArray(int offsetFromObjectStart, out WeakReference weakRef)
+    {
+        var array = new byte[1024];
+        weakRef = new WeakReference(array);
+
+        return ref Unsafe.SubtractByteOffset(
+            ref MemoryMarshal.GetArrayDataReference(array),
+            (nuint)(ArrayDataOffset - offsetFromObjectStart));
+    }
+}

--- a/TestApp/Tests/InteriorPointerTest.cs
+++ b/TestApp/Tests/InteriorPointerTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests interior pointer handling during GC
 /// </summary>
-public class InteriorPointerTest() : TestBase("Interior Pointers")
+public class InteriorPointerTest() : TestBase("Interior Pointers", GcFeature.InteriorPointers)
 {
     public override void Run()
     {

--- a/TestApp/Tests/JaggedArrayTest.cs
+++ b/TestApp/Tests/JaggedArrayTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests jagged arrays (arrays of arrays)
 /// </summary>
-public class JaggedArrayTest() : TestBase("Jagged Arrays")
+public class JaggedArrayTest() : TestBase("Jagged Arrays", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/LargeObjectTest.cs
+++ b/TestApp/Tests/LargeObjectTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests large object allocation (LOH)
 /// </summary>
-public class LargeObjectTest() : TestBase("Large Object Allocation")
+public class LargeObjectTest() : TestBase("Large Object Allocation", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/LatencyModeTest.cs
+++ b/TestApp/Tests/LatencyModeTest.cs
@@ -1,0 +1,42 @@
+using System.Runtime;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests GCSettings.LatencyMode: the getter must return a defined value and the setter must
+/// round-trip. A non-generational blocking GC can ignore the modes behaviorally, but real libraries
+/// toggle SustainedLowLatency, so the property must not crash.
+/// (docs/missing-features.md item 6.1)
+/// </summary>
+public class LatencyModeTest() : TestBase("GC Latency Mode", GcFeature.LatencyMode)
+{
+    public override void Run()
+    {
+        var original = GCSettings.LatencyMode;
+
+        if (!Enum.IsDefined(original))
+        {
+            throw new Exception($"GCSettings.LatencyMode returned an undefined value: {original}");
+        }
+
+        try
+        {
+            foreach (var mode in new[] { GCLatencyMode.Batch, GCLatencyMode.Interactive, GCLatencyMode.SustainedLowLatency })
+            {
+                GCSettings.LatencyMode = mode;
+
+                var read = GCSettings.LatencyMode;
+
+                if (read != mode)
+                {
+                    throw new Exception($"GCSettings.LatencyMode did not round-trip: set {mode}, read {read}");
+                }
+            }
+        }
+        finally
+        {
+            GCSettings.LatencyMode = original;
+        }
+    }
+}

--- a/TestApp/Tests/MemoryFootprintTest.cs
+++ b/TestApp/Tests/MemoryFootprintTest.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests that memory freed by collections is actually reused (or returned to the OS): churning
+/// through 2 GB of short-lived allocations with periodic explicit collections must not grow the
+/// process footprint by anywhere near 2 GB. Deliberately uses explicit GC.Collect calls so it does
+/// not depend on the allocation-trigger feature. (docs/missing-features.md item 1.2)
+/// </summary>
+public class MemoryFootprintTest() : TestBase("Memory Footprint Bounded", GcFeature.MemoryReuse)
+{
+    private const long TotalChurnBytes = 2L * 1024 * 1024 * 1024;
+    private const long MaxAllowedGrowthBytes = 512L * 1024 * 1024;
+
+    public override void Run()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long baseline = GetPrivateBytes();
+
+        const int rounds = 8;
+        const int arraysPerRound = 256; // 256 x 1 MB per round, 8 rounds = 2 GB total
+
+        for (int round = 0; round < rounds; round++)
+        {
+            AllocateRound(arraysPerRound);
+            GC.Collect();
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long final = GetPrivateBytes();
+        long growth = final - baseline;
+
+        if (growth > MaxAllowedGrowthBytes)
+        {
+            throw new Exception(
+                $"Process grew by {growth / (1024 * 1024)} MB after churning through " +
+                $"{TotalChurnBytes / (1024 * 1024)} MB of dead allocations with explicit collections " +
+                $"(baseline {baseline / (1024 * 1024)} MB, final {final / (1024 * 1024)} MB). " +
+                "Swept memory is not being reused or returned to the OS.");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocateRound(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            var array = new byte[1024 * 1024];
+            array[0] = (byte)i;
+        }
+    }
+
+    private static long GetPrivateBytes()
+    {
+        using var process = Process.GetCurrentProcess();
+        process.Refresh();
+        return process.PrivateMemorySize64;
+    }
+}

--- a/TestApp/Tests/MemoryInfoTest.cs
+++ b/TestApp/Tests/MemoryInfoTest.cs
@@ -1,0 +1,137 @@
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests GC.GetGCMemoryInfo: heap size and committed bytes must be non-zero, the collection index
+/// must increase across collections, and FinalizationPendingCount must reflect objects waiting for
+/// their finalizer. (docs/missing-features.md items 6.1, 10)
+/// </summary>
+public class MemoryInfoTest() : TestBase("GC Memory Info", GcFeature.MemoryInfo)
+{
+    private static readonly ManualResetEventSlim GateEvent = new(false);
+    private static volatile bool _gateEntered;
+
+    private sealed class Gate
+    {
+        ~Gate()
+        {
+            _gateEntered = true;
+            GateEvent.Wait();
+        }
+    }
+
+    private sealed class Finalizable
+    {
+        ~Finalizable()
+        {
+        }
+    }
+
+    public override void Run()
+    {
+        TestBasicNumbers();
+        TestFinalizationPendingCount();
+    }
+
+    public override void Cleanup()
+    {
+        GateEvent.Set();
+        GC.WaitForPendingFinalizers();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestBasicNumbers()
+    {
+        // Hold some live data so the heap is definitely non-empty
+        var liveData = new byte[4 * 1024 * 1024];
+        liveData[0] = 1;
+
+        GC.Collect();
+
+        var info = GC.GetGCMemoryInfo();
+
+        if (info.HeapSizeBytes <= 0)
+        {
+            throw new Exception($"GCMemoryInfo.HeapSizeBytes is {info.HeapSizeBytes}, expected > 0");
+        }
+
+        if (info.TotalCommittedBytes <= 0)
+        {
+            throw new Exception($"GCMemoryInfo.TotalCommittedBytes is {info.TotalCommittedBytes}, expected > 0");
+        }
+
+        if (info.Index <= 0)
+        {
+            throw new Exception($"GCMemoryInfo.Index is {info.Index}, expected > 0 after an induced collection");
+        }
+
+        long indexBefore = info.Index;
+
+        GC.Collect();
+
+        var infoAfter = GC.GetGCMemoryInfo();
+
+        if (infoAfter.Index <= indexBefore)
+        {
+            throw new Exception($"GCMemoryInfo.Index did not increase across collections ({indexBefore} -> {infoAfter.Index})");
+        }
+
+        GC.KeepAlive(liveData);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestFinalizationPendingCount()
+    {
+        GateEvent.Reset();
+        _gateEntered = false;
+
+        // First provably block the finalizer thread, then queue finalizable objects behind it so
+        // the pending count is stable when we read it.
+        CreateGate();
+        GC.Collect();
+
+        var deadline = Environment.TickCount64 + 10_000;
+
+        while (!_gateEntered)
+        {
+            if (Environment.TickCount64 > deadline)
+            {
+                throw new Exception("Test setup failed: the gate finalizer did not run within 10 seconds");
+            }
+
+            Thread.Sleep(10);
+        }
+
+        CreateFinalizables();
+        GC.Collect();
+
+        var info = GC.GetGCMemoryInfo();
+
+        if (info.FinalizationPendingCount < 1)
+        {
+            throw new Exception(
+                $"GCMemoryInfo.FinalizationPendingCount is {info.FinalizationPendingCount} while " +
+                "finalizable objects are queued behind a blocked finalizer thread");
+        }
+
+        GateEvent.Set();
+        GC.WaitForPendingFinalizers();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CreateGate()
+    {
+        _ = new Gate();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CreateFinalizables()
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            _ = new Finalizable();
+        }
+    }
+}

--- a/TestApp/Tests/MiscGcApiTest.cs
+++ b/TestApp/Tests/MiscGcApiTest.cs
@@ -1,0 +1,95 @@
+using System.Runtime;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// No-crash and documented-outcome checks for the rest of the public GC API surface: Collect
+/// overloads, memory pressure, RefreshMemoryLimit, NoGC-region callback registration, full-GC
+/// notifications and LOH compaction mode. Under NativeAOT, a NotImplementedException escaping any
+/// of these is a process fail-fast, so "returns a sane value" is the feature.
+/// (docs/missing-features.md item 6.1)
+/// </summary>
+public class MiscGcApiTest() : TestBase("Misc GC APIs", GcFeature.ApiSurface)
+{
+    public override void Run()
+    {
+        TestCollectOverloads();
+        TestMemoryPressure();
+        TestRefreshMemoryLimit();
+        TestNoGCRegionCallbackOutsideRegion();
+        TestFullGCNotification();
+        TestLohCompactionMode();
+    }
+
+    private static void TestCollectOverloads()
+    {
+        GC.Collect(0);
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized);
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: false);
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+    }
+
+    private static void TestMemoryPressure()
+    {
+        GC.AddMemoryPressure(100 * 1024 * 1024);
+        GC.RemoveMemoryPressure(100 * 1024 * 1024);
+    }
+
+    private static void TestRefreshMemoryLimit()
+    {
+        // No configuration changed: must succeed (refresh_success) without throwing
+        GC.RefreshMemoryLimit();
+    }
+
+    private static void TestNoGCRegionCallbackOutsideRegion()
+    {
+        try
+        {
+            GC.RegisterNoGCRegionCallback(1024 * 1024, () => { });
+            throw new Exception("GC.RegisterNoGCRegionCallback outside a NoGC region should have thrown InvalidOperationException");
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected (not_started)
+        }
+    }
+
+    private static void TestFullGCNotification()
+    {
+        // Documented outcomes: success (then cancel), or InvalidOperationException when the GC
+        // doesn't support notifications (stock throws this when concurrent GC is enabled).
+        try
+        {
+            GC.RegisterForFullGCNotification(10, 10);
+            GC.CancelFullGCNotification();
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected on configurations without notification support
+        }
+    }
+
+    private static void TestLohCompactionMode()
+    {
+        var original = GCSettings.LargeObjectHeapCompactionMode;
+
+        try
+        {
+            GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+
+            var read = GCSettings.LargeObjectHeapCompactionMode;
+
+            if (read != GCLargeObjectHeapCompactionMode.CompactOnce)
+            {
+                throw new Exception($"LargeObjectHeapCompactionMode did not round-trip: set CompactOnce, read {read}");
+            }
+        }
+        finally
+        {
+            GCSettings.LargeObjectHeapCompactionMode = original;
+        }
+    }
+}

--- a/TestApp/Tests/MixedAllocationPatternTest.cs
+++ b/TestApp/Tests/MixedAllocationPatternTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests interleaved allocation of small, medium, and large objects
 /// </summary>
-public class MixedAllocationPatternTest() : TestBase("Mixed Allocation Patterns")
+public class MixedAllocationPatternTest() : TestBase("Mixed Allocation Patterns", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/MultiDimensionalArrayTest.cs
+++ b/TestApp/Tests/MultiDimensionalArrayTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests multi-dimensional array allocation
 /// </summary>
-public class MultiDimensionalArrayTest() : TestBase("Multi-Dimensional Arrays")
+public class MultiDimensionalArrayTest() : TestBase("Multi-Dimensional Arrays", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/MultipleCollectionTest.cs
+++ b/TestApp/Tests/MultipleCollectionTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests multiple GC collections in succession
 /// </summary>
-public class MultipleCollectionTest() : TestBase("Multiple Collections")
+public class MultipleCollectionTest() : TestBase("Multiple Collections", GcFeature.Marking)
 {
     public override void Run()
     {

--- a/TestApp/Tests/NoGCRegionTest.cs
+++ b/TestApp/Tests/NoGCRegionTest.cs
@@ -1,0 +1,106 @@
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests GC.TryStartNoGCRegion / EndNoGCRegion. Declining the region (returning false) is a
+/// documented, legal outcome — so this test accepts both a working implementation and a declining
+/// one; what it does not accept is a crash, or a region that claims success but still collects.
+/// (docs/missing-features.md item 6.1)
+/// </summary>
+public class NoGCRegionTest() : TestBase("NoGC Region", GcFeature.NoGCRegion)
+{
+    public override void Run()
+    {
+        TestEndOutsideRegionThrows();
+        TestRegion();
+        TestTooLargeRequest();
+    }
+
+    private static void TestEndOutsideRegionThrows()
+    {
+        try
+        {
+            GC.EndNoGCRegion();
+            throw new Exception("GC.EndNoGCRegion outside a region should have thrown InvalidOperationException");
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestRegion()
+    {
+        bool started = GC.TryStartNoGCRegion(16 * 1024 * 1024);
+
+        if (!started)
+        {
+            // Declining is a documented outcome (start_no_gc_no_memory -> false)
+            return;
+        }
+
+        try
+        {
+            if (GCSettings.LatencyMode != GCLatencyMode.NoGCRegion)
+            {
+                throw new Exception($"Inside a NoGC region, GCSettings.LatencyMode should be NoGCRegion, got {GCSettings.LatencyMode}");
+            }
+
+            int countBefore = GC.CollectionCount(0);
+
+            // Allocate ~1 MB, well within the 16 MB budget: no collection may happen
+            for (int i = 0; i < 16; i++)
+            {
+                var array = new byte[64 * 1024];
+                array[0] = (byte)i;
+            }
+
+            int countAfter = GC.CollectionCount(0);
+
+            if (countAfter != countBefore)
+            {
+                throw new Exception($"A collection happened inside a NoGC region ({countBefore} -> {countAfter})");
+            }
+        }
+        finally
+        {
+            // The region may have been exited already if the budget was somehow exceeded
+            try
+            {
+                GC.EndNoGCRegion();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        if (GCSettings.LatencyMode == GCLatencyMode.NoGCRegion)
+        {
+            throw new Exception("GCSettings.LatencyMode still reports NoGCRegion after EndNoGCRegion");
+        }
+    }
+
+    private static void TestTooLargeRequest()
+    {
+        try
+        {
+            bool started = GC.TryStartNoGCRegion(1L * 1024 * 1024 * 1024 * 1024); // 1 TB
+
+            if (started)
+            {
+                GC.EndNoGCRegion();
+                throw new Exception("GC.TryStartNoGCRegion(1 TB) unexpectedly succeeded");
+            }
+
+            // false is acceptable for an implementation that declines with start_no_gc_no_memory
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // The stock behavior: start_no_gc_too_large -> ArgumentOutOfRangeException
+        }
+    }
+}

--- a/TestApp/Tests/NullReferenceTest.cs
+++ b/TestApp/Tests/NullReferenceTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests that null references are handled correctly
 /// </summary>
-public class NullReferenceTest() : TestBase("Null Reference Handling")
+public class NullReferenceTest() : TestBase("Null Reference Handling", GcFeature.Marking)
 {
     public override void Run()
     {

--- a/TestApp/Tests/PendingFinalizerRootsTest.cs
+++ b/TestApp/Tests/PendingFinalizerRootsTest.cs
@@ -1,0 +1,133 @@
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests that objects sitting in the finalization queue (queued, finalizer not run yet) are strong
+/// roots from the very start of the next collection: a short weak reference created during the
+/// pending-finalization window (via a trackResurrection reference) must survive a collection that
+/// happens while the object still waits for its finalizer.
+/// (docs/missing-features.md item 3.3)
+/// </summary>
+public class PendingFinalizerRootsTest() : TestBase("Pending Finalizer Roots", GcFeature.FinalizationQueueRoots)
+{
+    private static readonly ManualResetEventSlim GateEvent = new(false);
+    private static volatile bool _gateEntered;
+    private static volatile bool _payloadFinalized;
+
+    private sealed class Gate
+    {
+        ~Gate()
+        {
+            _gateEntered = true;
+            GateEvent.Wait();
+        }
+    }
+
+    private sealed class Payload
+    {
+        ~Payload() => _payloadFinalized = true;
+    }
+
+    public override void Run()
+    {
+        GateEvent.Reset();
+        _gateEntered = false;
+        _payloadFinalized = false;
+
+        // First provably block the finalizer thread: queue the gate and wait until its finalizer
+        // has *entered*. Only then queue the payload — it can never be dequeued before we're done.
+        BlockFinalizerThread();
+
+        var longWeak = CreatePayload();
+
+        GC.Collect();
+
+        if (_payloadFinalized)
+        {
+            throw new Exception("Test setup failed: the payload was finalized despite the blocked finalizer thread");
+        }
+
+        // The payload waits for its finalizer. A trackResurrection reference still sees it...
+        if (!longWeak.IsAlive)
+        {
+            throw new Exception("Long weak reference to a pending-finalization object was cleared");
+        }
+
+        // ...so we can legally hand out new references. Wrap one in a *short* weak reference.
+        var shortWeak = CreateShortWeak(longWeak);
+
+        GC.Collect();
+
+        // The object is still strongly reachable from the GC's perspective (it sits in the
+        // finalization queue), so the short weak reference must survive this collection.
+        if (!shortWeak.IsAlive)
+        {
+            throw new Exception(
+                "Short weak reference to an object awaiting finalization was cleared: " +
+                "the finalization queue must be scanned as roots at the start of the mark phase");
+        }
+
+        GateEvent.Set();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        if (!_payloadFinalized)
+        {
+            throw new Exception("Payload finalizer never ran after the gate was released");
+        }
+
+        if (shortWeak.IsAlive || longWeak.IsAlive)
+        {
+            throw new Exception("Payload survived after being finalized and collected");
+        }
+    }
+
+    public override void Cleanup()
+    {
+        // Never leave the finalizer thread blocked, even if the test failed
+        GateEvent.Set();
+        GC.WaitForPendingFinalizers();
+    }
+
+    private static void BlockFinalizerThread()
+    {
+        CreateGate();
+
+        GC.Collect();
+
+        var deadline = Environment.TickCount64 + 10_000;
+
+        while (!_gateEntered)
+        {
+            if (Environment.TickCount64 > deadline)
+            {
+                throw new Exception("Test setup failed: the gate finalizer did not run within 10 seconds");
+            }
+
+            Thread.Sleep(10);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CreateGate()
+    {
+        _ = new Gate();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreatePayload()
+    {
+        return new WeakReference(new Payload(), trackResurrection: true);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateShortWeak(WeakReference longWeak)
+    {
+        var target = longWeak.Target
+            ?? throw new Exception("Long weak reference lost its target while the object was pending finalization");
+
+        return new WeakReference(target, trackResurrection: false);
+    }
+}

--- a/TestApp/Tests/PinnedObjectTest.cs
+++ b/TestApp/Tests/PinnedObjectTest.cs
@@ -7,7 +7,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests GCHandle.Alloc with pinned objects - verifies that pinned objects don't move
 /// </summary>
-public class PinnedObjectTest() : TestBase("Pinned Objects")
+public class PinnedObjectTest() : TestBase("Pinned Objects", GcFeature.Handles)
 {
     public override void Run()
     {

--- a/TestApp/Tests/PohPinnedAllocTest.cs
+++ b/TestApp/Tests/PohPinnedAllocTest.cs
@@ -1,0 +1,108 @@
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests GC.AllocateArray / GC.AllocateUninitializedArray, in particular the pinned:true variant
+/// (GC_ALLOC_PINNED_OBJECT_HEAP): the array's data must stay at a stable address across
+/// collections, with contents intact.
+/// </summary>
+public class PohPinnedAllocTest() : TestBase("POH Pinned Allocation", GcFeature.Allocation)
+{
+    public override void Run()
+    {
+        TestPinnedArrayAddressStability();
+        TestUninitializedArrays();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static unsafe void TestPinnedArrayAddressStability()
+    {
+        var array = GC.AllocateArray<byte>(1024, pinned: true);
+
+        for (int i = 0; i < array.Length; i++)
+        {
+            array[i] = (byte)(i % 256);
+        }
+
+        nint before = GetDataAddress(array);
+
+        AllocateGarbage();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        nint after = GetDataAddress(array);
+
+        if (before != after)
+        {
+            throw new Exception($"Pinned array moved: {before:x} -> {after:x}");
+        }
+
+        for (int i = 0; i < array.Length; i++)
+        {
+            if (array[i] != (byte)(i % 256))
+            {
+                throw new Exception($"Pinned array content corrupted at index {i}: expected {(byte)(i % 256)}, got {array[i]}");
+            }
+        }
+
+        GC.KeepAlive(array);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestUninitializedArrays()
+    {
+        var uninit = GC.AllocateUninitializedArray<byte>(1024);
+
+        if (uninit.Length != 1024)
+        {
+            throw new Exception($"AllocateUninitializedArray returned wrong length: {uninit.Length}");
+        }
+
+        var uninitPinned = GC.AllocateUninitializedArray<int>(256, pinned: true);
+
+        if (uninitPinned.Length != 256)
+        {
+            throw new Exception($"AllocateUninitializedArray(pinned) returned wrong length: {uninitPinned.Length}");
+        }
+
+        // The arrays must be fully writable and readable
+        for (int i = 0; i < uninitPinned.Length; i++)
+        {
+            uninitPinned[i] = i;
+        }
+
+        GC.Collect();
+
+        for (int i = 0; i < uninitPinned.Length; i++)
+        {
+            if (uninitPinned[i] != i)
+            {
+                throw new Exception($"Uninitialized pinned array corrupted at index {i}");
+            }
+        }
+
+        GC.KeepAlive(uninit);
+        GC.KeepAlive(uninitPinned);
+    }
+
+    private static unsafe nint GetDataAddress(byte[] array)
+    {
+        fixed (byte* p = array)
+        {
+            return (nint)p;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocateGarbage()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            _ = new byte[1024];
+        }
+    }
+}

--- a/TestApp/Tests/ReferenceGraphTest.cs
+++ b/TestApp/Tests/ReferenceGraphTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests that the GC correctly traces reference graphs
 /// </summary>
-public class ReferenceGraphTest() : TestBase("Reference Graph")
+public class ReferenceGraphTest() : TestBase("Reference Graph", GcFeature.Marking)
 {
     public override void Run()
     {

--- a/TestApp/Tests/SelfReferencingObjectTest.cs
+++ b/TestApp/Tests/SelfReferencingObjectTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests objects that reference themselves
 /// </summary>
-public class SelfReferencingObjectTest() : TestBase("Self-Referencing Objects")
+public class SelfReferencingObjectTest() : TestBase("Self-Referencing Objects", GcFeature.Marking)
 {
     public override void Run()
     {

--- a/TestApp/Tests/StaticRootTest.cs
+++ b/TestApp/Tests/StaticRootTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests that static roots keep objects alive
 /// </summary>
-public class StaticRootTest() : TestBase("Static Roots")
+public class StaticRootTest() : TestBase("Static Roots", GcFeature.Marking)
 {
     private static object? _staticRoot;
 

--- a/TestApp/Tests/StressTest.cs
+++ b/TestApp/Tests/StressTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Stress test with many allocations
 /// </summary>
-public class StressTest() : TestBase("Stress Test")
+public class StressTest() : TestBase("Stress Test", GcFeature.Stress)
 {
     public override void Run()
     {

--- a/TestApp/Tests/StringTest.cs
+++ b/TestApp/Tests/StringTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests string allocation and GC behavior
 /// </summary>
-public class StringTest() : TestBase("String Handling")
+public class StringTest() : TestBase("String Handling", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/TestApp/Tests/StructWithReferencesTest.cs
+++ b/TestApp/Tests/StructWithReferencesTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests structs that contain reference type fields
 /// </summary>
-public class StructWithReferencesTest() : TestBase("Structs with References")
+public class StructWithReferencesTest() : TestBase("Structs with References", GcFeature.Marking)
 {
     public override void Run()
     {

--- a/TestApp/Tests/SuppressFinalizeSemanticsTest.cs
+++ b/TestApp/Tests/SuppressFinalizeSemanticsTest.cs
@@ -1,0 +1,88 @@
+using System.Runtime.CompilerServices;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Tests GC.SuppressFinalize semantics at the finalization scan: a suppressed dead object must be
+/// dropped outright — not resurrected for a spurious extra collection — its finalizer must never
+/// run, and suppress + ReRegisterForFinalize must compose correctly.
+/// (docs/missing-features.md item 5.1)
+/// </summary>
+public class SuppressFinalizeSemanticsTest() : TestBase("SuppressFinalize Semantics", GcFeature.SuppressFinalizeDrop)
+{
+    private static volatile int _finalizeCount;
+
+    private sealed class Suppressible
+    {
+        ~Suppressible() => _finalizeCount++;
+    }
+
+    public override void Run()
+    {
+        TestSuppressedObjectIsNotResurrected();
+        TestSuppressThenReRegisterRunsOnce();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestSuppressedObjectIsNotResurrected()
+    {
+        int countBefore = _finalizeCount;
+
+        var longWeak = CreateSuppressed();
+
+        GC.Collect();
+
+        // The stock GC drops a suppressed dead object at the finalization scan without
+        // resurrecting it: it must be fully gone after a single collection, so even a
+        // trackResurrection weak reference is cleared.
+        if (longWeak.IsAlive)
+        {
+            throw new Exception(
+                "A suppressed dead object was resurrected: it must be dropped at the finalization " +
+                "scan, not moved to the finalization queue");
+        }
+
+        GC.WaitForPendingFinalizers();
+
+        if (_finalizeCount != countBefore)
+        {
+            throw new Exception("The finalizer of a suppressed object ran");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateSuppressed()
+    {
+        var obj = new Suppressible();
+        GC.SuppressFinalize(obj);
+        return new WeakReference(obj, trackResurrection: true);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestSuppressThenReRegisterRunsOnce()
+    {
+        int countBefore = _finalizeCount;
+
+        CreateSuppressedAndReRegistered();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        if (_finalizeCount != countBefore + 1)
+        {
+            throw new Exception(
+                $"Suppress followed by ReRegisterForFinalize should run the finalizer exactly once, " +
+                $"ran {_finalizeCount - countBefore} time(s)");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CreateSuppressedAndReRegistered()
+    {
+        var obj = new Suppressible();
+        GC.SuppressFinalize(obj);
+        GC.ReRegisterForFinalize(obj);
+        GC.KeepAlive(obj);
+    }
+}

--- a/TestApp/Tests/SyncBlockCacheTest.cs
+++ b/TestApp/Tests/SyncBlockCacheTest.cs
@@ -8,8 +8,10 @@ namespace TestApp.Tests;
 /// Tests SyncBlock cache behavior - verifies syncblocks are created when needed
 /// and cleaned up when the owning objects are collected.
 /// </summary>
-public class SyncBlockCacheTest() : TestBase("SyncBlock Cache")
+public class SyncBlockCacheTest() : TestBase("SyncBlock Cache", GcFeature.SyncBlocks)
 {
+    public override bool RequiresCustomGcApi => true;
+
     public override void Run()
     {
         var gc = GcApi.TryCreate() ?? throw new Exception("Failed to initialize GC API");

--- a/TestApp/Tests/WeakReferenceTest.cs
+++ b/TestApp/Tests/WeakReferenceTest.cs
@@ -6,7 +6,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests weak reference behavior
 /// </summary>
-public class WeakReferenceTest() : TestBase("Weak References")
+public class WeakReferenceTest() : TestBase("Weak References", GcFeature.WeakReferences)
 {
     public override void Run()
     {

--- a/TestApp/Tests/WriteBarrierParamsTest.cs
+++ b/TestApp/Tests/WriteBarrierParamsTest.cs
@@ -1,0 +1,56 @@
+using ManagedDotnetGC.Api;
+using TestApp.TestFramework;
+
+namespace TestApp.Tests;
+
+/// <summary>
+/// Verifies the WriteBarrierParameters the GC passed to the EE: the WriteBarrierOp::Initialize
+/// contract wants real heap bounds and a non-null card table (debug-flavor runtimes assert on it).
+/// The ephemeral_low = -1 trick that disables the card-marking path is fine and is not asserted on.
+/// (docs/missing-features.md item 7.1)
+/// </summary>
+public class WriteBarrierParamsTest() : TestBase("Write Barrier Parameters", GcFeature.GcInternals)
+{
+    public override bool RequiresCustomGcApi => true;
+
+    public override void Run()
+    {
+        var gc = GcApi.TryCreate() ?? throw new Exception("Failed to initialize GC API");
+
+        var lowest = gc.GetWriteBarrierParameter(WriteBarrierParameterKind.LowestAddress);
+        var highest = gc.GetWriteBarrierParameter(WriteBarrierParameterKind.HighestAddress);
+
+        if (lowest == 0 || highest == 0)
+        {
+            throw new Exception(
+                $"The write barrier heap bounds were never set (lowest={lowest:x}, highest={highest:x}): " +
+                "Initialize must advertise the reservation range");
+        }
+
+        if (lowest >= highest)
+        {
+            throw new Exception($"Inverted write barrier heap bounds: lowest={lowest:x} >= highest={highest:x}");
+        }
+
+        // A live heap object must fall inside the advertised bounds
+        var probe = new byte[128];
+        var address = (ulong)Utils.GetAddress(probe);
+
+        if (address < lowest || address >= highest)
+        {
+            throw new Exception(
+                $"A heap object at {address:x} falls outside the advertised write barrier bounds [{lowest:x}, {highest:x})");
+        }
+
+        GC.KeepAlive(probe);
+
+        var cardTable = gc.GetWriteBarrierParameter(WriteBarrierParameterKind.CardTable);
+
+        if (cardTable == 0)
+        {
+            throw new Exception(
+                "The card table passed to the EE is null: the Initialize contract wants a real " +
+                "(dummy-sized) card table even if the ephemeral trick keeps it clean");
+        }
+    }
+}

--- a/TestApp/Tests/ZeroLengthArrayTest.cs
+++ b/TestApp/Tests/ZeroLengthArrayTest.cs
@@ -5,7 +5,7 @@ namespace TestApp.Tests;
 /// <summary>
 /// Tests allocation of zero-length arrays
 /// </summary>
-public class ZeroLengthArrayTest() : TestBase("Zero-Length Arrays")
+public class ZeroLengthArrayTest() : TestBase("Zero-Length Arrays", GcFeature.Allocation)
 {
     public override void Run()
     {

--- a/docs/missing-features.md
+++ b/docs/missing-features.md
@@ -1,0 +1,477 @@
+# Missing features: what ManagedDotnetGC needs to run any .NET app reliably, forever
+
+Scope: the GC stays a **non-generational, non-compacting, stop-the-world mark & sweep** by design.
+This document only lists *correctness and liveness* gaps against the contract the CoreCLR EE
+(`E:\git\runtime`, .NET 10) actually imposes on a standalone GC. Performance is explicitly out of scope.
+
+Legend:
+- 🟥 **Blocker** — crashes, corrupts memory, or hangs on workloads that plain, common .NET apps hit.
+- 🟧 **Correctness** — wrong observable semantics or unbounded leak over time; an app can run into it and misbehave.
+- 🟨 **Robustness** — only hit under specific-but-legitimate configurations (older runtimes, 32-bit, interpreter, Android, monitoring tools).
+- ⬜ **Diagnostic** — no app-level breakage; tooling/observability only. Included because "reliably in production" usually implies "survives having `dotnet-counters` attached".
+
+References are `runtime-file:line` for `E:\git\runtime\src\coreclr\...` and `gc-file:line` for this repo.
+
+---
+
+## 0. TL;DR — the list
+
+| # | Item | Severity |
+|---|------|----------|
+| 1.1 | No GC trigger policy — collections happen only on explicit `GC.Collect()` | 🟥 |
+| 1.2 | Memory is never reused (known) — plus the correctness work reuse drags in (zeroing, brick-table reset, decommit) | 🟥 |
+| 1.3 | OOM handling: `Alloc` must return `null`, never throw; today OOM = fail-fast | 🟥 |
+| 2.1 | `GcStartWork` / `BeforeGcScanRoots` / `AfterGcScanRoots` / `GcDone` never called | 🟥 |
+| 3.1 | Collectible types: LoaderAllocator objects are not kept alive during marking | 🟥 |
+| 3.2 | Ref-counted handles (COM / ComWrappers) never scanned, never cleared | 🟥 |
+| 3.3 | Objects awaiting finalization are marked too late in the cycle | 🟧 |
+| 3.4 | Dependent handles: frozen-segment primaries break the fixpoint (hang + dropped values) | 🟥 |
+| 4.1 | Handle table can't store handle types 10/11 (`WEAK_INTERIOR_POINTER`, `CROSSREFERENCE`) → index-out-of-range | 🟥 |
+| 4.2 | `HNDTYPE_WEAK_INTERIOR_POINTER` semantics (collectible statics) | 🟥 |
+| 4.3 | Legacy handle types for older EEs (async-pinned, sized-ref, weak-native-COM) | 🟨 |
+| 4.4 | `TraceRefCountedHandles` stub | 🟨 |
+| 5.1 | SuppressFinalize: suppressed objects are resurrected instead of dropped; skip path doesn't clear the bit | 🟧 |
+| 6.1 | `NotImplementedException` stubs reachable from public APIs (≈15 methods, each = fail-fast) | 🟥 |
+| 6.2 | Generation numbering consistency (`MaxGeneration`, `WhichGeneration`, frozen = `INT32_MAX`) | 🟧 |
+| 6.3 | `IsPromoted` / `GetContainingObject` / `IsHeapPointer` needed by the EE outside your own scan | 🟧 |
+| 7.1 | Write-barrier initialization passes null card table and zero heap bounds | 🟨 |
+| 8.1 | `alloc_bytes` accounting missing → negative `GC.GetAllocatedBytesForCurrentThread()` | ⬜ |
+| 8.2 | `GC_ALLOC_ALIGN8` / `ALIGN8_BIAS` (32-bit only) | 🟨 |
+| 8.3 | GC-from-allocation must toggle preemptive mode before `SuspendEE` | 🟥 (with 1.1) |
+| 9.1 | Conservative-GC / interpreter mode robustness | 🟨 |
+| 9.2 | Android / `FEATURE_JAVAMARSHAL` GC bridge | 🟨 |
+| 10.x | Diagnostics: `Diag*` throwing stubs, DAC vars, event sink, memory-info numbers | ⬜/🟥 under tooling |
+
+The stock GC's own ordering, used as the reference throughout: `runtime-gc/mark_phase.cpp:3033-3498`
+(the mark-phase driver) and `runtime-gc/interface.cpp:1827` (`GarbageCollectGeneration`).
+
+---
+
+## 1. Heap lifecycle
+
+### 1.1 🟥 No GC trigger policy
+
+`GCHeap.Alloc` (gc-GCHeap.cs:129) never initiates a collection: when a segment fills up it just
+allocates a new one. The only way a collection ever runs is an explicit `GC.Collect()`. In CoreCLR,
+**the GC owns the decision to collect** — the EE never calls `GarbageCollect` on the app's behalf;
+allocation is expected to trigger collection internally when a budget is exhausted
+(`runtime-vm/gchelpers.cpp:420-423`, `runtime-gc/interface.cpp:1827`).
+
+Consequence: any app that doesn't call `GC.Collect()` itself (i.e., almost all of them) grows
+monotonically until the 2 TB reservation or physical memory runs out. This and 1.2 are jointly the
+core of "run forever".
+
+What's needed: an allocation budget (bytes allocated since last GC) checked in the slow path of
+`Alloc`, plus optionally a memory-load trigger. Precision is irrelevant; existence is not.
+See 8.3 for a mandatory detail (preemptive-mode toggle) when you do this.
+
+### 1.2 🟥 Memory reuse (the one you named) — and what it drags in
+
+Sweep (gc-GCHeap.Sweep.cs:10) creates free objects but nothing ever consumes them; `SegmentManager.FreeSegment`
+(gc-SegmentManager.cs:43) has no caller. When you implement reuse, these become correctness items
+(they're all free today only because memory is virgin):
+
+- **Zeroing**: the JIT and EE assume newly allocated objects are zeroed unless
+  `GC_ALLOC_ZEROING_OPTIONAL` (`runtime-gc/gcinterface.h:1090`), and the pre-object sync-block word
+  **must** be zero even in the optional case (`runtime-gc/interface.cpp:1456-1460`). Your sweep already
+  zeroes reclaimed ranges (gc-GCHeap.Sweep.cs:27), which is sufficient — keep that invariant when free
+  lists appear, including for ranges handed out as fresh allocation contexts.
+- **Brick-table staleness** (gc-Segment.cs:39): entries are only ever raised, never reset when objects die
+  and memory is re-carved. After reuse, `FindClosestObjectBelow` can return a position that is no longer
+  an object start → interior-pointer resolution walks garbage → marking corruption. The brick table must
+  be rebuilt/adjusted on sweep or on re-allocation of a range.
+- **Stale sync-block indices**: cleaning dead objects' memory (you do) plus the sync-block weak scan
+  (you do) covers this; just preserve both when the allocator changes.
+- **Decommit** (optional for correctness, mandatory for "forever" on real machines): dead dedicated
+  segments should be returned via `VirtualFree`/`MEM_DECOMMIT`; the plumbing exists in
+  gc-NativeAllocator.cs:128 but is unused.
+- The 2 TB address-space reservation is a hard wall (gc-GCHeap.cs:14). With reuse it stops being a
+  practical limit, but exhaustion must still surface as managed OOM (1.3), not a fail-fast.
+
+### 1.3 🟥 OOM must surface as `null` from `Alloc`
+
+The EE's contract: `IGCHeap::Alloc` returns `nullptr` on failure and the EE throws
+`OutOfMemoryException` (`runtime-vm/gchelpers.cpp:498-504`; contract comment `runtime-gc/gcinterface.h:917-930`).
+Today `NativeAllocator.Allocate` throws a managed `OutOfMemoryException`
+(gc-NativeAllocator.cs:63,76) that propagates out of an `UnmanagedCallersOnly` frame → NativeAOT
+fail-fast. Additionally:
+
+- `Alloc` should attempt a collection before giving up (once 1.1 exists).
+- Oversized/overflowing requests are already rejected by the EE before `Alloc` is called
+  (`runtime-vm/gchelpers.cpp:302-330, 610-647`) — you don't need to validate sizes, only fail cleanly.
+- `RegisterForFinalization` may return `false` to signal "couldn't grow the finalization queue"; the EE
+  converts that to a managed OOM (`runtime-vm/comutilnative.cpp:1039-1042`). Your version grows a managed
+  array (gc-GCHeap.Finalization.cs:59) — wrap the growth so failure returns `false` instead of throwing.
+
+---
+
+## 2. The GC↔EE brackets around a collection
+
+### 2.1 🟥 `GcStartWork`, `BeforeGcScanRoots`, `AfterGcScanRoots`, `GcDone` are never called
+
+`GarbageCollect` (gc-GCHeap.cs:79) goes straight `SuspendEE → mark → sweep → RestartEE`. The stock GC
+interleaves four EE callbacks, and each one does real work (`runtime-vm/gcenv.ee.cpp`):
+
+| Callback | When (stock) | What the EE does | If skipped |
+|---|---|---|---|
+| `GcStartWork(condemned, max_gen)` | GC start, after suspend (`runtime-gc/collect.cpp:982`) | `ExecutionManager::CleanupCodeHeaps()` (reclaims JIT code of unloaded methods), type-system log cleanup, `Interop::OnGCStarted` → ComWrappers `BeginExternalObjectReferenceTracking` (`gcenv.ee.cpp:339-360`) | JIT code heaps leak forever; ComWrappers/WinRT reference tracking never engages |
+| `BeforeGcScanRoots(condemned, false, false)` | just before root scan (`runtime-gc/mark_phase.cpp:3033`) | ObjC interop begin, IL-stub byref validation (`gcenv.ee.cpp:78-96`) | ObjC interop breaks (macOS); harmless on Windows but free to call |
+| `AfterGcScanRoots(condemned, max_gen, sc)` | after all strong marking (stack+handles+dependent), **before** weak clearing (`runtime-gc/mark_phase.cpp:3385`) | `DetachRCWs()` — detaches **unmarked** RCWs so the RCW cache can't hand out dead wrappers; ComWrappers `DetachNonPromotedObjects` (`gcenv.ee.cpp:100-117`) | COM/`ComWrappers` objects resurrect or leak; use-after-free in interop-heavy apps (WinForms/WPF/WinUI) |
+| `GcDone(condemned)` | GC end (`runtime-gc/collect.cpp:1493`) | `Interop::OnGCFinished` → `EndExternalObjectReferenceTracking` (`gcenv.ee.cpp:367-377`) | pairs with `GcStartWork`; tracker never completes |
+
+All four are already bound in gc-Interfaces/IGCToCLR.cs:27-44 — they just need call sites. Note:
+- Report `condemned = 2` so the "full GC" paths engage (the ComWrappers tracker only runs when
+  `condemned >= 2`, `runtime-vm/interoplibinterface_shared.cpp:82-98`). You already use 2 in `GcScanRoots`.
+- `AfterGcScanRoots` internally calls back into **your** `IsPromoted` (see 6.3) — implement that first
+  or the callback itself will fail-fast.
+
+### 2.2 ✅ For the record: things you already do correctly here
+
+Suspension bracket, `FixAllocContexts` before marking (including the zero-both-fields rule,
+`runtime-gc/gcinterface.ee.h:283-288`), sync-block weak scan positioned after long-weak clearing
+(matches `runtime-gc/mark_phase.cpp:3498`), `EnableFinalization` after restart, short-weak before /
+long-weak+dependent after the finalization scan (matches `mark_phase.cpp:3424/3489`),
+`EagerFinalized` consultation, normal-before-critical finalizer dequeue order
+(matches `runtime-gc/finalization.cpp:224-247`), free-object plugging for walkability, and the
+`SetGCInProgress`/`Set/ResetWaitForGCEvent` surface — which it turns out the **EE drives itself** from
+`SuspendEE`/`RestartEE` (`runtime-vm/threadsuspend.cpp:3252, 3577, 5363, 5505`). Only nit there: create
+`_gcEvent` initially **set** (stock does) so a racing `WaitUntilGCComplete` before the first GC can't hang.
+
+---
+
+## 3. Marking-protocol gaps
+
+### 3.1 🟥 Collectible types: the LoaderAllocator edge
+
+The rule (`runtime-gc/gc.cpp:7470`, `go_through_object_cl`): when marking an object whose MethodTable is
+**collectible**, the GC must *also mark that type's managed `LoaderAllocator` object*, obtained via
+`IGCToCLR.GetLoaderAllocatorObjectForGC(obj)` (`runtime-vm/gcenv.ee.cpp:514` →
+`runtime-vm/methodtable.cpp:8737`). The LoaderAllocator object is only referenced from native code via a
+*long weak* handle (`runtime-vm/loaderallocator.cpp:1069`) — the GC-side edge is exactly what keeps a
+collectible assembly alive while instances of its types exist.
+
+Your `EnumerateObjectReferences` (gc-GCObject.cs:68) never adds this edge. Consequence: with any
+collectible `AssemblyLoadContext` (plugin systems, test runners, hot reload) the LoaderAllocator dies
+while instances live → the native loader heaps (MethodTables, JIT code) are freed → the next virtual
+call or GC touching a surviving instance reads freed memory. Hard crash, hard to debug.
+
+Implementation notes:
+- The `Collectible` flag is `0x00200000` in the MT flags (`runtime-vm/methodtable.h:3812`; the GC-side
+  mirror with the .NET 8 compat shim is `runtime-gc/env/gcenv.object.h:54,94`). Add it to
+  gc-MethodTable.cs and, in the mark loop, for collectible MTs push
+  `GetLoaderAllocatorObjectForGC(obj)` (null-checked) alongside the field references.
+- The EE additionally reports LoaderAllocator objects of *executing* code as stack roots by itself
+  (`GcReportLoaderAllocator`, `runtime-vm/gcenv.ee.common.cpp:222`) — that part arrives through your
+  existing `ScanRoots` callback and needs nothing.
+
+### 3.2 🟥 Ref-counted handles (`HNDTYPE_REFCOUNTED`) are invisible to your GC
+
+`MarkPhase` scans only `STRONG`+`PINNED` (gc-GCHeap.Mark.cs:77) and clears only
+`WEAK_SHORT`/`WEAK_LONG`/`DEPENDENT` (gc-GCHeap.Mark.cs:21-24). Ref-counted handles — created for every
+classic COM CCW and every `ComWrappers`-managed object (`runtime-vm/appdomain.hpp:792`) — need both:
+
+- **Scan** (with the strong handles): for each refcounted handle whose target isn't already marked, call
+  `IGCToCLR.RefCountedHandleCallbacks(obj)` (bound at gc-Interfaces/IGCToCLR.cs:50; EE impl
+  `runtime-vm/gcenv.ee.cpp:379-409`) and promote the target iff it returns true (stock:
+  `PromoteRefCounted`, `runtime-gc/objecthandle.cpp:80-108, 1150-1177`).
+- **Clear** (with the long-weak handles, i.e. *after* the finalization scan): null the handle if the
+  target is still unmarked (stock includes `REFCOUNTED` in `Ref_CheckReachable`'s list,
+  `runtime-gc/objecthandle.cpp:1222`).
+
+Failure mode without it: a `[ComVisible]` object handed to native code with a positive external ref
+count is collected → native calls into a freed CCW; or (if you conservatively treated them as strong)
+CCWs leak forever. Affects COM interop, drag-and-drop, WinRT/CsWinRT, WinUI 3.
+
+### 3.3 🟧 Objects awaiting finalization must be roots *early* in the mark phase
+
+Stock order (`runtime-gc/mark_phase.cpp:3176`): the f-reachable objects (queued for the finalizer thread
+in a previous GC, not yet finalized) are promoted as roots right after stack scanning — **before**
+handle scanning, dependent-handle fixpoint, `AfterGcScanRoots` (RCW detach) and short-weak clearing
+(`runtime-gc/finalization.cpp:289-310`).
+
+Your equivalent objects (`_freachableQueue`/`_criticalFreachableQueue` leftovers) only get marked inside
+`ScanForFinalization` (gc-GCHeap.Mark.cs:56), which runs *after* short-weak clearing. Consequences:
+
+- To be precise about the weak-handle impact: a short weak that exists at the GC that first *discovers*
+  the object dead is cleared in that GC, before the finalization scan — identical in both GCs, and the
+  documented semantic. The divergence is only for short weaks **created during the pending-finalization
+  window** (obtainable legitimately: `WeakReference(trackResurrection: true).Target`, another object's
+  finalizer, resurrection). At the *next* GC, stock keeps them alive because the f-reachable queue is a
+  strong root from step one; yours clears them because the queue is only marked after short-weak clearing.
+  Narrow, but observably different from C#.
+- The stronger reason to fix the ordering: once 3.2/2.1 exist, the EE consults `IsPromoted` mid-GC
+  (RCW detach, refcounted-handle decisions, ComWrappers `DetachNonPromotedObjects`) and would treat
+  objects whose finalizers haven't run yet as dead — detaching interop state a finalizer still needs.
+
+Fix: at the top of `MarkPhase`, mark everything in both f-reachable queues (transitively), then keep
+`ScanForFinalization` for the newly dead only.
+
+### 3.4 🟥 Dependent handles vs frozen-segment (and other non-heap) primaries
+
+`ScanDependentHandles` (gc-GCHeap.Mark.cs:87) tests `primary->IsMarked()`. Frozen-segment objects are
+never marked by your GC (by design). Two bugs follow:
+
+1. **Dropped values**: primary = interned string literal (allocated on the frozen object heap since
+   .NET 8, `runtime-vm/gchelpers.cpp:1156`) → `primary->IsMarked()` is always false → the secondary is
+   never promoted → a `ConditionalWeakTable` keyed on a literal string (or any frozen object) has its
+   value collected while the key is eternally alive → `GetValue` returns a dangling/collected object.
+2. **Infinite loop**: primary marked, secondary frozen → `!secondary->IsMarked()` is permanently true →
+   `markedObjects = true` every pass → `MarkPhase` never terminates. A `CWT<object, string>` whose value
+   is a literal is enough.
+
+Rule to implement: "is alive" for dependent-handle purposes = `IsMarked() || !_nativeAllocator.IsInRange(obj)`
+(same treatment you already give weak handles in `ClearHandles`, gc-GCHeap.Sweep.cs:40), and "needs
+promotion" must be false for out-of-range secondaries. Stock semantics reference:
+`runtime-gc/objecthandle.cpp:230-292` (promotion + pair clearing — note stock clears **both** slots,
+which your `handle->Clear()` already matches).
+
+How the stock GC avoids both defects: (a) `mark_ro_segments` artificially sets the mark bit on **every**
+object in registered frozen segments at the start of each mark phase (`runtime-gc/mark_phase.cpp:3652-3665` —
+"all objects on ro segs are live … artificially mark all of them"), and (b) every liveness question in
+handle scanning funnels through `GCHeap::IsPromoted`, which treats **any address outside the GC heap
+bounds as promoted** (`runtime-gc/interface.cpp:783-784`; regions variant `:790`), applied to primaries
+and secondaries alike (`runtime-gc/objecthandle.cpp:244-246`). So "outside the managed heap ⇒ always
+alive" is exactly the stock behavior.
+
+---
+
+## 4. Handle-table structural gaps
+
+### 4.1 🟥 The handle-type enum stops at 9; .NET 10 goes to 11
+
+gc-Types.cs:193 declares `Max = HNDTYPE_WEAK_NATIVE_COM (9)`, and `GCHandleStore` sizes `_lists` as
+`Max + 1` (gc-GCHandleStore.cs:9,18). The current runtime defines
+(`runtime-gc/gcinterface.h:417-557`):
+
+- `HNDTYPE_WEAK_INTERIOR_POINTER = 10` — **actively created** by the EE for collectible statics
+  (`runtime-vm/loaderallocator.cpp:2385, 2465, 2518` via `AppDomain::CreateWeakInteriorHandle`,
+  `runtime-vm/appdomain.hpp:779`).
+- `HNDTYPE_CROSSREFERENCE = 11` — Java GC bridge (`FEATURE_JAVAMARSHAL`; Android, plus Debug/Checked
+  builds of the runtime).
+
+First collectible assembly → `CreateHandleWithExtraInfo` indexes `_lists[10]` → `IndexOutOfRangeException`
+→ fail-fast. Extend the enum and the per-type lists (stock reserves 13 slots,
+`runtime-gc/handletableconstants.h:17`).
+
+### 4.2 🟥 `HNDTYPE_WEAK_INTERIOR_POINTER` semantics
+
+Cheap for a non-moving GC. Contract (`runtime-gc/objecthandle.cpp:150-189, 1224, 1394-1426`):
+
+- **Never a root** (weak on the primary).
+- **Cleared with the long-weak handles** (it's in `Ref_CheckReachable`'s type list), i.e. after the
+  finalization scan.
+- Extra-info word = address of a location holding an interior pointer into the primary; only compacting
+  GCs must update it — you just need to null the handle when the primary dies.
+
+Add it to the `ClearHandles([WEAK_LONG, DEPENDENT, …])` list.
+
+### 4.3 🟨 Legacy handle types (only if you want to support .NET 6/7 hosts)
+
+On .NET 8+ the VM never creates these (`runtime-gc/gcinterface.h:504, 517, 534` — "no longer used in the
+VM"); a standalone GC that only targets .NET 10 can ignore their scanning semantics. For completeness,
+the semantics older EEs expect:
+`ASYNCPINNED (7)` = pinned root + `WalkAsyncPinnedForPromotion` for the Overlapped's buffer array
+(gc-Interfaces/IGCToCLR.cs:259); `SIZEDREF (8)` = strong root (size bookkeeping optional);
+`WEAK_NATIVE_COM (9)` = short-weak clearing. `HNDTYPE_VARIABLE (4)` is dead code in all versions —
+keep the slot, never scan it.
+
+### 4.4 🟨 `TraceRefCountedHandles` no-op
+
+gc-GCHandleManager.cs:115 stubs it. It's used by ObjC interop (`FEATURE_OBJCMARSHAL`) to enumerate
+ref-counted handles — irrelevant on Windows, required on macOS with `ObjectiveCMarshal`.
+
+---
+
+## 5. Finalization refinements
+
+The big pieces (registration at alloc, resurrection with full closure, critical/normal split via the MT
+flag, eager finalization of WeakReference, ReRegister-via-header-bit, normal-drains-before-critical) are
+all present and match `runtime-gc/finalization.cpp`. Two divergences remain:
+
+### 5.1 🟧 SuppressFinalize handling at scan and dequeue
+
+Stock `ScanForFinalization` (`runtime-gc/finalization.cpp:367-377`): a **dead + suppressed** finalizable
+object is *dropped* from the queue (and the bit cleared) — it is **not resurrected**. Your
+`PrepareForFinalization` (gc-GCHeap.Finalization.cs:72) doesn't check the bit, so suppressed dead objects
+are moved to the f-reachable queue, *resurrected* (marked with their whole graph), and only skipped at
+dequeue time — surviving at least one extra GC for no reason.
+
+Worse, the dequeue skip (gc-GCHeap.Finalization.cs:33-36) doesn't **clear** the bit, while stock does
+(`runtime-vm/finalizerthread.cpp:253-259`). Sequence that goes wrong: suppress → object dies → skipped
+at dequeue (bit still set, object now out of the queue) → object is resurrected by other means and
+`GC.ReRegisterForFinalize` is called → your `RegisterForFinalization` sees the bit, clears it and
+returns **without enqueuing** (gc-GCHeap.Finalization.cs:51-55) — that early-return is only valid while
+the object is still in the queue (`runtime-gc/interface.cpp:2535-2539`). Result: finalizer never runs.
+
+Fix: in `PrepareForFinalization`, treat `HasFinalizerRun` like `EagerFinalized` (drop + clear bit,
+don't enqueue); clear the bit when skipping in `GetNextFinalizable`.
+
+### 5.2 ⬜ Signal semantics
+
+You call `EnableFinalization(count > 0)`; stock calls it (with `true`) only when there is work
+(`runtime-gc/interface.cpp:1960`). Calling with `false` is harmless today but pointless — minor.
+
+---
+
+## 6. The `IGCHeap` surface: every throwing stub is a process crash
+
+Under NativeAOT, a `NotImplementedException` escaping an `UnmanagedCallersOnly` boundary is a fail-fast.
+So every stub in gc-GCHeap.NotImplemented.cs that the EE or BCL can reach is a latent crash, not a TODO.
+Reachable ones, with the concrete trigger and the correct cheap implementation:
+
+| Method (gc-GCHeap.NotImplemented.cs) | Reached from | Correct stub for this GC |
+|---|---|---|
+| `WhichGeneration` (:89) | `GC.GetGeneration(obj)` (`runtime-vm/comutilnative.cpp:630`), sync-block bookkeeping (`runtime-vm/syncblk.cpp:1156`) | `2` for heap objects; **`INT32_MAX` for frozen-segment / non-heap** (`runtime-gc/gcinterface.h:804`) |
+| `GetGenerationBudget` (:270) | **`RuntimeEventSource` EventCounter `gen-0-gc-budget`** — polled the moment `dotnet-counters`/any EventListener attaches (`runtime-libs/RuntimeEventSource.cs:85` → QCall `runtime-vm/comutilnative.cpp:1174-1197`) | any constant (stock semantics: gen budget in bytes) |
+| `GetGcLatencyMode` / `SetGcLatencyMode` (:61/:67) | `GCSettings.LatencyMode` get/set — used by real libraries (SustainedLowLatency toggles) | store + return the value; return success (0) from the setter |
+| `StartNoGCRegion` / `EndNoGCRegion` (:95/:101) | `GC.TryStartNoGCRegion` / `EndNoGCRegion` | **declining is legal**: return `start_no_gc_no_memory` → managed `false`; `end_no_gc_not_in_progress` (`runtime-gc/gcinterface.h:351-386`, mapping `GC.CoreCLR.cs:507-578`). Or implement for real: "success" promises **no GC until End** (budget pre-commit) |
+| `EnableNoGCRegionCallback` (:264) | `GC.RegisterNoGCRegionCallback` | `not_started` |
+| `RefreshMemoryLimit` (:258) | `GC.RefreshMemoryLimit()` | `0` (`refresh_success`) |
+| `IsPromoted` (:107) | ComWrappers `DetachNonPromotedObjects` + RCW code during **your own** `AfterGcScanRoots` call (`runtime-vm/interoplibinterface_comwrappers.cpp:275`, `runtime-vm/runtimecallablewrapper.cpp:828`); also the pattern for weak scans (`runtime-gc/gcscan.cpp:116`) | during GC: `obj->IsMarked() \|\| !IsInRange(obj)`; outside GC: `true` |
+| `GetContainingObject` (:166) | profiler root scanning (`runtime-vm/gcenv.ee.cpp:606`), byref validation (`runtime-vm/stubhelpers.cpp:140`) | you already have the machinery — brick table + walk from `ScanRoots`'s interior path; factor it out and return null for non-heap |
+| `IsHeapPointer` (:113) | object validation, marshaling validation, GCStress (`runtime-vm/object.cpp:558`, `runtime-vm/stubhelpers.cpp:620`) | `_nativeAllocator.IsInRange(ptr)` (plus frozen segments if `small_heap_only == false`… stock excludes frozen: keep it heap-only) |
+| `IsEphemeral` (:121) | sync-block ephemeral path (`runtime-vm/syncblk.cpp:929`) — unreachable today only because `condemned(2) < maxgen(0)` is false | `false` |
+| `IsLargeObject` (:148) | profiler / ETW paths | `false` (or size ≥ 85000) |
+| `RuntimeStructuresValid` (:127) | debugger/DAC-adjacent checks | `true` |
+| `GetGenerationWithRange` (:252) | profiler generation-bounds walks | fill with one pseudo-generation spanning the heap |
+| `IsValidSegmentSize`/`IsValidGen0MaxSize`/`GetValidSegmentSize`/`SetReservedVMLimit` (:13-35) | hosting/config paths | `true`/`true`/a constant/no-op |
+| `WaitUntilConcurrentGCComplete(Async)`, `Temporary(En/Dis)ableConcurrentGC` (:37-59) | hosting APIs, profiler `ForceGC` prep | no-op / `S_OK` — "no concurrent GC" means always complete |
+| `SetYieldProcessorScalingFactor` (:138) | EE startup measurement on some paths | no-op |
+| `Destructor`, `Uproot`, handle-store `Destructor` | shutdown | no-op |
+
+Also in this category though not throwing: `WaitForFullGCApproach/Complete` correctly return
+`wait_full_gc_na = 4`, and `RegisterForFullGCNotification` returning `false` maps to a documented
+managed `InvalidOperationException` — both fine.
+
+### 6.2 🟧 Generation-numbering consistency
+
+Pick one story and apply it everywhere. Recommended: pretend to be a stock GC that only ever does full
+collections — `GetMaxGeneration() = 2` (stock, and BCL code loops `0..MaxGeneration`), `WhichGeneration =
+2` (SOH; 3/4 for LOH/POH if you ever tag them; `INT32_MAX` frozen), `GetCondemnedGeneration() = 2` (already),
+`CollectionCount(g) = _gcCount` for all g (already). Today `GetMaxGeneration() = 0`
+(gc-GCHeap.Stats.cs:31) happens to work — e.g. the sync-block scan's ephemeral branch is skipped only
+because `2 < 0` is false (`runtime-vm/syncblk.cpp:885`) — but it's accidental, and
+`FinalizerThreadWait` keys off `CollectionCount(GetMaxGeneration())` (`runtime-vm/finalizerthread.cpp:740-778`),
+so keep whatever you choose monotonic and coherent.
+
+### 6.3 (folded into the table above — `IsPromoted`, `GetContainingObject`, `IsHeapPointer` are prerequisites for 2.1/3.2.)
+
+---
+
+## 7. Write barrier initialization
+
+🟨 `Initialize` passes only `ephemeral_low = -1` (gc-GCHeap.cs:65-72); `card_table`, `lowest_address`,
+`highest_address` stay null/zero. The ephemeral trick is sound for the release x64 barriers
+(`runtime-vm/amd64/JitHelpers_Fast.asm:152-155` — value below `g_ephemeral_low` exits before any card
+write), but the documented `WriteBarrierOp::Initialize` contract wants a non-null card table and real
+bounds, and debug-flavor runtimes assert on it (`runtime-vm/gcenv.ee.cpp:1105-1116`). Cheap fix: pass
+`lowest_address`/`highest_address` = your 2 TB reservation range and a small dummy card-table allocation
+sized for it (it will never be dirtied given the ephemeral trick). That also makes
+`g_lowest/g_highest_address`-based VM fast checks truthful, and covers non-x64 barrier flavors whose
+instruction order differs. Bonus: with fixed bounds you never need `StompResize`.
+
+---
+
+## 8. Allocation details
+
+### 8.1 ⬜ `alloc_bytes` accounting
+
+You never touch `gc_alloc_context.alloc_bytes`/`alloc_bytes_uoh`.
+`GC.GetAllocatedBytesForCurrentThread()` computes `alloc_bytes + alloc_bytes_uoh − (alloc_limit − alloc_ptr)`
+(`runtime-vm/comutilnative.cpp:847-858`) → **negative numbers** with a live context. Increment
+`alloc_bytes` by the window size whenever you hand out/refresh a context. Same family:
+`GetTotalAllocatedBytes() = 0`, `GetTotalBytesInUse() = 0` (→ `GC.GetTotalMemory` returns 0),
+`GetMemoryInfo` zeros — all wrong-number-only, but trivially computable from `SegmentManager`.
+
+### 8.2 🟨 `GC_ALLOC_ALIGN8` / `GC_ALLOC_ALIGN8_BIAS`
+
+Only emitted on 32-bit (x86/ARM32) for `double`/`long` alignment (`runtime-vm/gchelpers.cpp:678-690,
+1271-1285`). Irrelevant while you target win-x64 exclusively; a hard requirement the day you don't.
+
+### 8.3 🟥 (with 1.1) Triggering GC from `Alloc` requires the preemptive-mode dance
+
+`GC.Collect` reaches you on a thread already in preemptive mode, but an allocation-triggered GC starts
+on a thread in **cooperative** mode; calling `SuspendEE` from cooperative mode self-deadlocks. Stock
+switches first (`runtime-gc/interface.cpp:1890-1895`). Use the already-bound
+`EnablePreemptiveGC`/`DisablePreemptiveGC` (gc-Interfaces/IGCToCLR.cs:79-84) around the collection, and
+add a real GC lock so two racing triggers don't run two back-to-back collections.
+
+### 8.4 ⬜ `GetLOHThreshold() = nint.MaxValue`
+
+Means the EE never sets `GC_ALLOC_LARGE_OBJECT_HEAP` (`runtime-vm/gchelpers.cpp:664` requires
+`size >= 85000 && size >= GetLOHThreshold()`). Harmless with a unified heap; return 85000 if you ever
+want the flag for bookkeeping.
+
+---
+
+## 9. Conditional environments
+
+### 9.1 🟨 Conservative GC / interpreter mode
+
+With `DOTNET_GCConservative=1` — and **unconditionally under the interpreter**
+(`runtime-vm/gcenv.ee.cpp:1236-1242`) — every plausible stack word is reported as
+`GC_CALL_INTERIOR | GC_CALL_PINNED` (`runtime-vm/gcenv.ee.cpp:156-189`). Your interior resolution
+already rejects out-of-range pointers; two hardening points: don't treat a resolved **free object** as
+live (stock skips them, `runtime-gc/interface.cpp:1100`), and make interior lookup robust against
+pointers into segment metadata (brick table region / headers).
+
+### 9.2 🟨 Android / `FEATURE_JAVAMARSHAL`
+
+`HNDTYPE_CROSSREFERENCE` handles + `GcProcessBridgeObjects` + `TriggerClientBridgeProcessing`
+(`runtime-gc/mark_phase.cpp:3334`, `runtime-vm/gcenv.ee.cpp:411`) form the .NET↔Java bridge. Not needed
+on Windows; allocate the handle slot (4.1) so its mere existence can't crash you, and ignore the rest
+unless you target Android.
+
+---
+
+## 10. Diagnostics & tooling (explicitly outside "app correctness", included for honesty)
+
+- 🟥-under-tooling: every `Diag*` method throws (gc-GCHeap.NotImplemented.cs:172-236). A profiler attach,
+  `dotnet-gcdump`, or an EventPipe session requesting heap walks calls into them → fail-fast **of the
+  app**. Minimum bar: make them all silent no-ops. (Same for `StressHeap` if anyone sets GCStress.)
+- ⬜ `DiagGCStart`/`DiagGCEnd`/`DiagUpdateGenerationBounds`/`DiagWalkFReachableObjects` (IGCToCLR side)
+  are never invoked → profilers see no GC events; ETW/EventPipe GC events absent (`EventSink` unused).
+- ⬜ `GcDacVars` is never populated → SOS/`dotnet-dump`/WinDbg can't inspect the heap (you compensate
+  with your own DAC trick for names, gc-Dac/DacManager.cs).
+- ⬜ EventCounters coherence: `gc-heap-size` (→ `GetTotalMemory`), `gen-x-gc-count`
+  (→ `CollectionCount`), `GetMemoryLoad`, `GetLastGCPercentTimeInGC` — all zeros/synthetic today.
+
+---
+
+## Appendix A — target collection cycle (stock-equivalent order for this design)
+
+```text
+lock(gc)                                    // one collection at a time (8.3)
+if cooperative: EnablePreemptiveGC()        // only for alloc-triggered GCs (8.3)
+SuspendEE(SUSPEND_FOR_GC)
+GcStartWork(2, 2)                                            // 2.1
+FixAllocContexts()                                           // ✅ have
+BeforeGcScanRoots(2, false, false)                           // 2.1
+mark f-reachable queues (prior GCs' pending finalizables)    // 3.3
+GcScanRoots(promote, 2, 2, sc)                               // ✅ have (stack, statics, LA-of-running-code)
+    └── each mark: collectible MT ⇒ also mark LoaderAllocator object   // 3.1
+scan STRONG + PINNED handles                                 // ✅ have
+scan REFCOUNTED handles via RefCountedHandleCallbacks        // 3.2
+dependent-handle fixpoint (frozen/non-heap primary = alive)  // ✅ have + 3.4
+AfterGcScanRoots(2, 2, sc)                                   // 2.1 (needs IsPromoted)
+clear WEAK_SHORT (+ WEAK_NATIVE_COM if supporting old EEs)   // ✅ have
+ScanForFinalization: EagerFinalized → suppressed = drop+clearbit → resurrect rest  // ✅ have + 5.1
+dependent-handle fixpoint again                              // ✅ have
+clear WEAK_LONG + DEPENDENT + REFCOUNTED + WEAK_INTERIOR_POINTER      // ✅ have + 3.2 + 4.2
+SyncBlockCacheWeakPtrScan(...)                               // ✅ have
+sweep (rebuild brick tables, feed free lists, decommit)      // 1.2
+GcDone(2)                                                    // 2.1
+RestartEE(true)
+EnableFinalization(pending > 0)                              // ✅ have
+```
+
+## Appendix B — implementation bugs noticed in passing (not "missing features")
+
+1. **Dedicated large-segment sizing** (gc-GCHeap.cs:160-180): the segment is allocated with exactly
+   `size` bytes of object space but the object is placed at `ObjectStart + IntPtr.Size`, so its tail
+   extends `IntPtr.Size` bytes past `End`. Page-rounding in `NativeAllocator.Allocate` usually hides it;
+   an allocation whose header+brick+size lands exactly on a page boundary AVs. Allocate
+   `size + SizeOfObject` like the normal path does.
+2. **`_gcEvent` initial state** — see 2.2; create it set.
+3. **`GetNextFinalizable` doesn't clear `HasFinalizerRun` when skipping** — covered in 5.1 but it's a
+   one-line fix independent of the rest.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -253,21 +253,21 @@ vtable is positional, so the Api and GC projects must ship from the same build):
 - `GetWriteBarrierParameter(WriteBarrierParameterKind)` — reads the parameters captured by the
   `StompWriteBarrier` wrapper (all write-barrier updates must go through it).
 
-One probe encodes an edge the current machinery gets wrong: `GetContainingObject(first byte of the
-object)` must resolve to that object (stock `find_object`: `obj <= ptr < obj + size`), but the
-interior path in `ScanRoots` walks `WalkHeapObjects(closestBelow, root)` with an *exclusive* upper
-bound, so a pointer exactly at an object start resolves to nothing — implementing 6.3 by factoring
-out that path will trip this probe until the bound is fixed (and the same off-by-one means a
-`GC_CALL_INTERIOR` root pointing at an object's first byte doesn't mark it today).
+One probe encodes an edge the machinery originally got wrong: `GetContainingObject(first byte of
+the object)` must resolve to that object (stock `find_object`: `obj <= ptr < obj + size`). The
+interior path in `ScanRoots` used to walk `WalkHeapObjects(closestBelow, root)` with an *exclusive*
+upper bound, so a pointer exactly at an object start resolved to nothing and a `GC_CALL_INTERIOR`
+root at an object's first byte didn't mark it. The bound is fixed (`root + 1`); implementing 6.3 by
+factoring out that path keeps the probe green.
 
 That marking bug also has a direct end-to-end test, `InteriorPointerObjectStartTest` (no custom API
 needed): a byref synthesized at the very first byte of a `byte[]` (via `Unsafe.SubtractByteOffset`
 from the array data reference) is the object's only root across a `GC.Collect()`, observed through a
 `WeakReference`; a control scenario does the same with a byref to the first data byte. Validated
-green on stock (the byref at the method-table word does keep the object alive there) and red on the
-custom GC (control passes, object-start scenario fails). It sits under `GcFeature.InteriorPointers`
-— the *implemented* feature it belongs to — so it fails in the default run by design: it is a
-confirmed bug in existing functionality, not a missing feature.
+green on stock (the byref at the method-table word does keep the object alive there); it initially
+failed on the custom GC exactly as predicted (control passes, object-start scenario fails) and went
+green with the `ScanRoots` bound fix. It sits under `GcFeature.InteriorPointers` — the implemented
+feature it belongs to — as the permanent regression guard.
 
 ## 4. Category C — subprocess tests
 
@@ -339,8 +339,8 @@ unaffected, but assertions about objects promoted during the resurrection wave m
    no fail-fast), which is the designed red state until items 6.3 / 2.1 / 7.1 land.
 
 7. ✅ **`InteriorPointerObjectStartTest`** — end-to-end test for the object-start interior-pointer
-   marking bug (see Category B section above). Gated under the *implemented* `InteriorPointers`
-   feature: it fails in the default run by design until the walk bound is fixed.
+   marking bug (see Category B section above). Confirmed the bug red-first, then went green with
+   the `ScanRoots` walk-bound fix; stays under the implemented `InteriorPointers` feature.
 8. ✅ **First implemented item**: `WhichGeneration` — the single-generation story: heap object → 0
    (= `GetMaxGeneration`), non-heap (frozen) → `int.MaxValue` for stock API parity. The only hard
    EE constraint is consistency of the pair: the EE indexes `GetMaxGeneration + 1`-sized arrays
@@ -352,9 +352,8 @@ unaffected, but assertions about objects promoted during the resurrection wave m
    (`RefreshMemoryLimit`, …).
 
 Validation state: stock GC `--all-features` = 50 passed / 4 skipped (sync-block + the 3 Category B
-tests, which need the custom GC API) / 0 failed; custom GC default = 35 passed / 18 skipped (pending
-features) / **1 failed, exit 1** — `InteriorPointerObjectStartTest`, the confirmed object-start
-marking bug (control scenario passes).
+tests, which need the custom GC API) / 0 failed; custom GC default = 36 passed / 18 skipped (pending
+features) / 0 failed, exit 0.
 
 Every test landed green-on-stock; each feature flag flips from "skipped" to "running" on the custom
 GC as the corresponding item in `missing-features.md` is implemented.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,360 @@
+# Test plan for the missing-features backlog
+
+Goal: for every item in `missing-features.md`, either a test that is **green on the stock GC and red on
+ManagedDotnetGC until the feature is implemented**, or an explicit justification for why no such test is
+practical. Constraints:
+
+- Every test must run (and pass) on the stock GC — that's what validates the test itself. The only
+  exception category is tests that *require* the custom GC API (like the existing sync-block tests).
+- New tests are **feature-gated**: on the custom GC they are skipped unless their feature is opted in,
+  so the suite stays green while features land one by one. On the stock GC the gate is ignored and
+  everything runs.
+- Scope: .NET 10, win-x64 only. Everything tied to 32-bit (`ALIGN8`), Android (`CROSSREFERENCE` bridge),
+  older EEs (async-pinned / sized-ref / weak-native-COM), conservative/interpreter mode is **out of scope**.
+
+A general note on methodology: several of these tests pin down semantics I inferred from reading the
+runtime (e.g. exactly when a ComWrappers CCW counts as "rooted", what `GC.GetGeneration` returns for a
+frozen literal). The workflow is: write the test, run it on the **stock** GC first, adjust the
+assertions until they describe what stock actually does — at that point the test *is* the spec, which
+is exactly the philosophy of this suite.
+
+---
+
+## 1. Infrastructure changes (prerequisite, small)
+
+### 1.1 Skip support + feature gating in `TestRunner` — ✅ implemented
+
+- `GcFeature` enum (`TestApp.TestFramework/GcFeature.cs`): one value per functional area. **Every**
+  test declares its feature via the `TestBase` constructor — the existing 32 tests are decorated too
+  (`Allocation`, `Marking`, `Stress`, `InteriorPointers`, `Handles`, `WeakReferences`,
+  `DependentHandles`, `Finalization`, `FrozenSegments`, `SyncBlocks`), plus one pending value per
+  missing feature (`CollectibleAssemblies`, `RefCountedHandles`, `FinalizationQueueRoots`,
+  `FrozenDependentHandles`, `SuppressFinalizeDrop`, `ApiSurface`, `LatencyMode`, `NoGCRegion`,
+  `EventCounters`, `AllocationAccounting`, `MemoryInfo`, `GcTriggering`, `MemoryReuse`,
+  `HardLimitOom`, `GcEvents`, `GcInternals`).
+- **`Program.PendingFeatures`** is the hardcoded source of truth for what is *not implemented yet*.
+  Tests gated on a pending feature are reported as **Skipped** unless overridden on the command line:
+  - `TestApp.exe --feature X[,Y]` — run *only* the tests of those features, pending or not;
+  - `TestApp.exe --all-features` — run everything, including pending;
+  - `TestApp.exe <TestName>` — a test requested by name always bypasses the pending gate.
+  CI runs with no arguments → only implemented features are exercised. Starting work on a feature =
+  removing its enum value from `PendingFeatures` and watching its tests fail. Validating pending
+  tests against the stock GC = running with `--all-features` there.
+- `TestBase.RequiresCustomGcApi` — skipped on the **stock** GC (the `GcApi.TryCreate() != null`
+  probe); `SyncBlockCacheTest` is migrated to this and now reports *Skipped* on stock instead of
+  failing. `run-tests.cmd` forwards `--feature`/`--all-features`.
+
+### 1.2 Hang watchdog — ✅ implemented (with a caveat)
+
+A background watchdog thread is armed with each test's name and timeout (default 120 s,
+`TestBase.TimeoutSeconds`); on expiry it writes `WATCHDOG: test X exceeded its timeout` to stderr and
+fails fast, so CI shows *which* test hung. **Caveat discovered during design**: the watchdog is a
+managed thread — a hang *inside the GC with the EE suspended* (e.g. the frozen-primary dependent-handle
+livelock) suspends the watchdog too. Those hangs can only be caught by an external, out-of-process
+timeout (CI-level, or the subprocess helper below). The in-proc watchdog still covers the other hang
+class: deadlocked `WaitForPendingFinalizers`, runaway managed loops.
+
+### 1.3 Subprocess helper
+
+A small helper that re-launches `TestApp.exe --child <TestName>` with extra environment variables and
+asserts on the exit code. Needed for the hard-limit OOM test (env vars must be set before runtime
+startup) and useful later to isolate any test that fail-fasts the process. The child runs the given
+test through the normal runner (`RunSingle` already exists) but with a distinctive exit code protocol
+(e.g. 42 = child scenario succeeded) so a crash is distinguishable from a clean failure.
+
+---
+
+## 2. Category A — cross-GC behavioral tests (the bulk)
+
+| Test class | Feature gate | Doc item | Status on custom GC today |
+|---|---|---|---|
+| `CollectibleAssemblyTest` | `CollectibleAssemblies` | 3.1 + 4.1/4.2 | crash (handle type 10 OOR) |
+| `DynamicMethodTest` | `CollectibleAssemblies` | 3.1 | likely crash/UAF |
+| `ComWrappersTest` | `RefCountedHandles` | 3.2 (+2.1 indirectly) | premature collection |
+| `PendingFinalizerRootsTest` | `FinalizationQueueRoots` | 3.3 | short weak cleared early |
+| `FrozenDependentHandleTest` | `FrozenDependentHandles` | 3.4 | hang / dropped value |
+| `SuppressFinalizeSemanticsTest` | `SuppressFinalizeDrop` | 5.1 | wrong resurrection |
+| `GenerationApiTest` | `GenerationApis` (implemented) | 6.1/6.2 | green — `WhichGeneration`/`GetMaxGeneration` landed |
+| `LatencyModeTest` | `LatencyMode` | 6.1 | fail-fast |
+| `NoGCRegionTest` | `NoGCRegion` | 6.1 | fail-fast |
+| `MiscGcApiTest` | `ApiSurface` | 6.1 | fail-fast (`RefreshMemoryLimit`, …) |
+| `EventCountersTest` | `EventCounters` | 6.1 (`GetGenerationBudget`) | fail-fast on listener attach |
+| `AllocationAccountingTest` | `AllocationAccounting` | 8.1 | negative / zero values |
+| `MemoryInfoTest` | `MemoryInfo` | 6.1/10 | all-zero values |
+| `GcTriggerTest` | `GcTriggering` | 1.1 | red (no collection happens) |
+| `MemoryFootprintTest` | `MemoryReuse` | 1.2 | red (unbounded growth) |
+| `PohPinnedAllocTest` | *(none — should pass already)* | 8.x sanity | green (regression guard) |
+| `DependentHandleResurrectionTest` | *(none — should pass already)* | 3.3/3.4 adjacent | green (regression guard) |
+
+Details:
+
+### `CollectibleAssemblyTest` — the control feature, fully testable in-proc
+`AssemblyBuilder.DefineDynamicAssembly(..., AssemblyBuilderAccess.RunAndCollect)` emits a type with an
+instance method returning a constant and a static field (`object` type).
+1. **Instance liveness**: create instance, drop the builder/`Type` references, `GC.Collect()` several
+   times, then call the method and `GetType().FullName` — on a broken GC the LoaderAllocator (and the
+   MethodTable behind it) is gone. This is the direct test of the mark-time LoaderAllocator edge.
+2. **Collectible statics**: write/read the emitted static across collections. First static access makes
+   the EE create a `HNDTYPE_WEAK_INTERIOR_POINTER` handle → also covers 4.1/4.2 (today: index-out-of-range
+   in `GCHandleStore`).
+3. **Unloadability**: drop everything, take a `WeakReference` to the emitted `Type`, collect in a retry
+   loop (unload is multi-GC on stock) → weak ref must die, proving we don't *leak* collectible
+   assemblies either (the long-weak handle on the LoaderAllocator must clear).
+
+### `DynamicMethodTest`
+Same feature area, different mechanism: build a `DynamicMethod`, get its delegate, drop the
+`DynamicMethod`, collect, invoke the delegate repeatedly. Then drop the delegate and verify
+collectability via weak ref + retries.
+
+### `ComWrappersTest`
+Minimal `ComWrappers` subclass (empty vtable is fine for lifetime purposes).
+1. `GetOrCreateComInterfaceForObject(obj)` → native `IntPtr` holds a ref. Drop all managed refs to
+   `obj`, keep a short `WeakReference`. Collect → **must stay alive** (refcounted handle answers "rooted"
+   via `RefCountedHandleCallbacks`).
+2. `Marshal.Release` the pointer → collect → weak ref must die (refcounted handle behaves long-weak and
+   is cleared).
+3. Roundtrip sanity: `GetOrCreateObjectForComInstance` returns the same instance while rooted.
+The exact rooted-vs-refcount semantics get pinned empirically on stock (see methodology note).
+
+### `PendingFinalizerRootsTest`
+1. Block the finalizer thread with a "gate" object whose finalizer waits on a `ManualResetEventSlim`.
+2. Make finalizable object `F` unreachable, `GC.Collect()` → `F` is queued behind the gate.
+3. Resurrect a reference via a pre-created `WeakReference(F, trackResurrection: true).Target`, wrap it
+   in a **new short** `WeakReference`, drop the strong ref, `GC.Collect()` again.
+4. Assert the short weak is **alive** (stock: f-reachable queue is a strong root from the top of the
+   mark phase). 5. Release the gate, `WaitForPendingFinalizers`, collect → everything dead.
+Queue order between gate and `F` isn't guaranteed → verify `F`'s finalizer hasn't run at step 3 and
+retry the whole scenario otherwise (bounded retries).
+
+### `FrozenDependentHandleTest`
+1. `DependentHandle(primary: "literal string", secondary: new object())` → collect → secondary alive
+   (weak-ref probe). Covers the dropped-value defect.
+2. `DependentHandle(primary: live normal object, secondary: "literal string")` → `GC.Collect()`
+   **returns** (covers the livelock — this is the test the watchdog exists for).
+3. `ConditionalWeakTable<string, object>` with a literal key → value survives collections.
+Sanity probe at start: record `GC.GetGeneration("literal")` so the test log shows whether the literal
+was actually frozen on this runtime (assertions hold either way on stock — interning roots it forever).
+
+### `SuppressFinalizeSemanticsTest`
+1. **No spurious resurrection**: finalizable object, `GC.SuppressFinalize`, track:true weak, drop,
+   single `GC.Collect()` → long weak must be **dead immediately** (stock drops suppressed objects at the
+   finalization scan; yours currently resurrects them for one extra GC).
+2. **Suppress + ReRegister while alive**: suppress, `ReRegisterForFinalize`, drop, collect + WFPF →
+   finalizer ran exactly once.
+3. **Suppress → never finalized**: suppress, drop, collect + WFPF → finalizer never ran (may already be
+   covered by `FinalizerTest`; keep here for completeness of the semantic group).
+
+### `GenerationApiTest`
+`GC.GetGeneration(new object())` ∈ [0, 2]; `GC.MaxGeneration == 2`; `GC.GetGeneration` on a frozen
+literal == whatever stock says (expected `int.MaxValue`, verify at impl time); `GC.CollectionCount(g)`
+non-negative, monotonic, increases after `GC.Collect()` for all g ∈ 0..MaxGeneration.
+
+### `LatencyModeTest`
+Read `GCSettings.LatencyMode`; set `Interactive`, `SustainedLowLatency`, `Batch` and read each back;
+restore. (Today: fail-fast on the getter.)
+
+### `NoGCRegionTest`
+- `GC.TryStartNoGCRegion(16MB)`: if `false` → pass (declining is a documented outcome — this keeps the
+  test green if you choose the "always decline" implementation). If `true`: snapshot
+  `CollectionCount`, allocate ~1 MB, assert no collection happened, `EndNoGCRegion()`, assert a
+  subsequent `GC.Collect()` works.
+- `GC.TryStartNoGCRegion(ridiculously large)` → expect the documented exception (verify exact type on
+  stock; expected `ArgumentOutOfRangeException` from `start_no_gc_too_large`).
+- `GC.EndNoGCRegion()` outside a region → `InvalidOperationException`.
+
+### `MiscGcApiTest`
+All no-crash + documented-outcome checks: `GC.Collect(gen, mode, blocking, compacting)` across modes
+(incl. `Aggressive`); `GC.AddMemoryPressure(100MB)` + `RemoveMemoryPressure`; `GC.RefreshMemoryLimit()`;
+`GC.RegisterNoGCRegionCallback(size, cb)` → documented exception outside a region;
+`GC.RegisterForFullGCNotification` → either succeeds (then `CancelFullGCNotification`) or throws
+`InvalidOperationException` — both accepted, because "decline" is legal for a non-concurrent GC;
+`GCSettings.LargeObjectHeapCompactionMode` set/reset.
+
+### `EventCountersTest`
+In-proc `EventListener` that enables the `System.Runtime` EventSource with
+`EventCounterIntervalSec=1`, waits (≤10 s) for counter payloads, asserts at least one interval arrived
+and specifically that the `gen-0-gc-budget` counter was delivered — that counter polls
+`GC.GetGenerationBudget(0)`, the exact call that fail-fasts your GC the moment `dotnet-counters`
+attaches. This is the "survives monitoring" test.
+
+### `AllocationAccountingTest`
+`GC.GetAllocatedBytesForCurrentThread()` before/after allocating ~10 MB of dropped arrays: delta ≥
+10 MB **and both samples ≥ 0** (catches the current negative-value bug); `GC.GetTotalAllocatedBytes()`
+monotonic and ≥ the per-thread delta; `GC.GetTotalMemory(false) > 0` while holding live data.
+
+### `MemoryInfoTest`
+After allocating live data + one collect: `GCMemoryInfo.HeapSizeBytes > 0`,
+`TotalCommittedBytes > 0`, `Index` increases across collections; with the finalizer gate from
+`PendingFinalizerRootsTest`, `FinalizationPendingCount ≥ 1` (tolerance settled on stock first).
+
+### `GcTriggerTest` — yes, the trigger policy is testable
+Snapshot `GC.CollectionCount(0)`; allocate ~256 MB of immediately-dropped 1 MB arrays **without any
+explicit `GC.Collect()`**; assert `CollectionCount(0)` increased. Stock's gen0 budget makes this
+deterministic; your GC stays red until allocation-triggered collection exists. (If the trigger
+deadlocks on the preemptive-mode issue — 8.3 — this test hangs and the watchdog names it.)
+
+### `MemoryFootprintTest` — memory reuse
+Churn ~2 GB total (1 MB arrays, dropped immediately) with an **explicit** `GC.Collect()` every 256 MB
+(deliberately independent of `GcTriggering`), then assert `Process.GetCurrentProcess().PrivateMemorySize64`
+(refreshed) stays under a generous threshold (~600 MB; stock lands far below). Red until sweep actually
+feeds a free list / decommits.
+
+### Ungated regression guards (expected green on both today)
+- `PohPinnedAllocTest`: `GC.AllocateArray<byte>(n, pinned: true)` + `GC.AllocateUninitializedArray`;
+  data pointer stable across collections; contents intact.
+- `DependentHandleResurrectionTest`: dependent handle whose primary is a *finalizable* object —
+  secondary must stay alive while the primary awaits finalization and die after it's finalized
+  (exercises the second dependent-handle pass, which you already have; cheap insurance while touching
+  that code for 3.4).
+
+---
+
+## 3. Category B — custom-GC-API-only (skipped on stock, like the sync-block tests)
+
+Several items that have no managed-code trigger on the stock GC *are* testable on the custom GC by
+extending `ManagedDotnetGC.Api` (`IGc`). These tests carry `RequiresCustomGcApi = true` + feature
+`GcInternals`, and are the sanctioned exception to the "green on both" philosophy:
+
+- **`GcInternalsProbeTest`** — `IGc` methods that route test-provided addresses through the GC's own
+  query implementations (doc 6.3), turning them into unit tests of load-bearing machinery:
+  - `GetContainingObject(interior)`: take a real object address (`Utils.GetAddress`), probe interior
+    pointers into its middle, its first byte, one-past-the-end, a stack address, null — assert the
+    resolved object start (validates the brick-table lookup, which becomes correctness-critical the
+    moment memory reuse lands and bricks can go stale).
+  - `IsHeapPointer`: heap object → true; stack/native/frozen addresses → per stock semantics.
+  - `IsPromoted` (outside GC): asserts the safe answer (true — the EE treats false as "dead, safe
+    to detach" from the `AfterGcScanRoots` callback). `WhichGeneration` needs no probe:
+    `GC.GetGeneration` maps directly to it (implemented — `GenerationApiTest` covers it), and
+    `IsEphemeral` has no reachable release-mode caller for this GC (its only VM call site is behind
+    `GetCondemnedGeneration() < GetMaxGeneration()`), so its stub deliberately keeps throwing to
+    flag any unexpected call.
+- **`GcCallbackBracketTest`** — counters for `GcStartWork`/`BeforeGcScanRoots`/`AfterGcScanRoots`/
+  `GcDone` recorded by the GC itself, asserted to increment exactly once per induced collection and
+  in the right order (doc 2.1). Self-instrumentation — it proves the calls happen, not that the EE
+  liked them — but it catches regressions like "sweep refactor dropped the GcDone call". The
+  EE-observable side of 2.1 is covered by `ComWrappersTest` (Category A).
+- **`WriteBarrierParamsTest`** — expose the `WriteBarrierParameters` passed at `Initialize` (doc 7.1):
+  assert non-null card table and bounds covering the reservation once that fix lands.
+
+These require small `IGc` additions (counters + pass-through wrappers), mirroring how
+`GetSyncBlockCacheCount` already works.
+
+**Landed.** The `IGc` surface (methods in declaration order after `GetSyncBlockCacheCount` — the
+vtable is positional, so the Api and GC projects must ship from the same build):
+
+- `GetContainingObject` / `IsHeapPointer` / `IsPromoted` — pass-throughs to the `IGCHeap`
+  implementations, with `NotImplementedException` (and any other exception) mapped to the `GcProbe`
+  sentinels instead of a fail-fast, so the tests fail cleanly while the stubs remain.
+- `GetGcCallbackCount(GcCallbackKind)` — bracket counters. `GCHeap.ManagedApi.cs` contains
+  `NotifyGcStartWork`/`NotifyBeforeGcScanRoots`/`NotifyAfterGcScanRoots`/`NotifyGcDone` wrappers
+  (counter + order-violation state machine + the actual `_gcToClr` call): **when implementing 2.1,
+  call these wrappers from the collection cycle** — they are the sanctioned call sites, and using
+  them is what turns `GcCallbackBracketTest` green.
+- `GetWriteBarrierParameter(WriteBarrierParameterKind)` — reads the parameters captured by the
+  `StompWriteBarrier` wrapper (all write-barrier updates must go through it).
+
+One probe encodes an edge the current machinery gets wrong: `GetContainingObject(first byte of the
+object)` must resolve to that object (stock `find_object`: `obj <= ptr < obj + size`), but the
+interior path in `ScanRoots` walks `WalkHeapObjects(closestBelow, root)` with an *exclusive* upper
+bound, so a pointer exactly at an object start resolves to nothing — implementing 6.3 by factoring
+out that path will trip this probe until the bound is fixed (and the same off-by-one means a
+`GC_CALL_INTERIOR` root pointing at an object's first byte doesn't mark it today).
+
+That marking bug also has a direct end-to-end test, `InteriorPointerObjectStartTest` (no custom API
+needed): a byref synthesized at the very first byte of a `byte[]` (via `Unsafe.SubtractByteOffset`
+from the array data reference) is the object's only root across a `GC.Collect()`, observed through a
+`WeakReference`; a control scenario does the same with a byref to the first data byte. Validated
+green on stock (the byref at the method-table word does keep the object alive there) and red on the
+custom GC (control passes, object-start scenario fails). It sits under `GcFeature.InteriorPointers`
+— the *implemented* feature it belongs to — so it fails in the default run by design: it is a
+confirmed bug in existing functionality, not a missing feature.
+
+## 4. Category C — subprocess tests
+
+### `HeapHardLimitOOMTest` — feature `HardLimitOom` (doc 1.3)
+Parent spawns `TestApp.exe --child HeapHardLimitOOM` with `DOTNET_GCHeapHardLimit=0x4000000` (64 MB,
+env var must precede runtime start — hence subprocess). Child: allocate 1 MB arrays into a list until
+`OutOfMemoryException` is **caught**; verify the heap still works afterwards (drop list, collect,
+allocate); exit 42. Parent asserts exit code 42. Green on stock. For your GC this implies two small
+features: honoring `GCHeapHardLimit` (read via `GetIntConfigValue` — you already have the plumbing) and
+returning `null` from `Alloc` instead of throwing. This is the only sane way to test OOM without
+grinding the whole machine into the pagefile.
+
+### (Optional, tier 3) `GcEventsTest` — feature `GcEvents`
+In-proc `EventListener` on `Microsoft-Windows-DotNETRuntime` with the GC keyword (0x1): after
+`GC.Collect()`, expect `GCStart`/`GCEnd` events. Green on stock; red on yours until the `EventSink` is
+wired. Only worth it if/when you decide diagnostics are in scope. A gcdump-style test (heap walk via
+`Microsoft.Diagnostics.NETCore.Client` against self) is also possible for the `Diag*` no-op work, same
+tier.
+
+## 5. Category D — not realistically testable (and why)
+
+| Doc item | Why not |
+|---|---|
+| 7.1 write-barrier init params (stock side) | Only observable as asserts under a Debug/Checked runtime build. On the custom GC: covered by `WriteBarrierParamsTest` (Category B). |
+| 6.3 query methods (stock side) | No managed trigger on a release runtime (profiler/debugger only). On the custom GC: covered by `GcInternalsProbeTest` (Category B); they also become load-bearing via `ComWrappersTest`/2.1. |
+| 2.1 bracket calls, EE side | The EE-observable effects are covered by `ComWrappersTest`; the calls themselves by `GcCallbackBracketTest` (Category B). `GcStartWork`'s code-heap cleanup is a native leak with no managed observable on either GC. |
+| 4.3 legacy handle types | Requires hosting the GC in .NET 6/7 — out of scope by your constraint. |
+| 9.1 conservative/interpreter, 8.2 ALIGN8, 9.2 Android bridge | Out of scope (platform/config). |
+| 8.3 preemptive-mode dance | No direct test; failure mode (deadlock) is surfaced by `GcTriggerTest` + an external timeout (in-proc watchdog is blind to EE-suspended hangs). |
+| 5.2 `EnableFinalization(false)` nuance | Not observable from managed code. |
+| 10 DAC/SOS | Manual/debugger-driven by nature. |
+
+### Empirically validated semantics (from Phase 4)
+
+Blocking the finalizer thread with "gate" finalizers is **only deterministic if you block first**:
+queue the gate alone, spin until a flag set at the *entry* of its finalizer confirms the thread is
+stuck, and only then queue the payload objects. Bracketing the payload between two gates in a single
+batch is not enough — in a full-suite run (with other tests' finalizables interleaved in the queue)
+the payload can be dequeued before either gate is reached, which made `PendingFinalizerRootsTest`
+flaky until it switched to block-first. `MemoryInfoTest` uses the same pattern.
+
+### Empirically validated semantics (from Phase 1)
+
+`DependentHandleResurrectionTest`, written per this plan, initially asserted that a *short* weak
+reference to the dependent secondary survives while the primary awaits finalization — **the stock GC
+failed that assertion**. The real semantic: the secondary is promoted as part of the resurrection
+wave (second dependent-handle pass, *after* short-weak severing), so short weak references to both
+primary **and** secondary are cleared in the GC that queues the primary; only
+`trackResurrection: true` references observe either object while the primary sits in the finalizer
+queue. The test now encodes that. Keep this in mind when writing `PendingFinalizerRootsTest` — its
+scenario (short weak created while the object is *already* f-reachable, surviving the *next* GC) is
+unaffected, but assertions about objects promoted during the resurrection wave must use long weaks.
+
+## 6. Suggested order — status
+
+1. ✅ **Phase 0**: runner infra (skip state, feature gate, watchdog, `ChildProcess` helper;
+   `SyncBlockCacheTest` migrated to `RequiresCustomGcApi`).
+2. ✅ **Phase 1**: ungated guards (`PohPinnedAllocTest`, `DependentHandleResurrectionTest`).
+3. ✅ **Phase 2**: `GcTriggerTest`, `MemoryFootprintTest`, `HeapHardLimitOomTest` (`--oom-child`).
+4. ✅ **Phase 3**: `GenerationApiTest`, `LatencyModeTest`, `NoGCRegionTest`, `MiscGcApiTest`,
+   `EventCountersTest`.
+5. ✅ **Phase 4 (Category A)**: `CollectibleAssemblyTest`, `DynamicMethodTest`, `ComWrappersTest`,
+   `PendingFinalizerRootsTest`, `FrozenDependentHandleTest`, `SuppressFinalizeSemanticsTest`,
+   `AllocationAccountingTest`, `MemoryInfoTest`.
+6. ✅ **Category B probes** (`GcInternalsProbeTest`, `GcCallbackBracketTest`,
+   `WriteBarrierParamsTest`) — `IGc` extended (probe pass-throughs with `GcProbe` sentinels,
+   bracket counters, write-barrier parameter capture), GC republished and validated. On the custom
+   GC with `--feature GcInternals` all three fail cleanly today (stub → sentinel → readable failure,
+   no fail-fast), which is the designed red state until items 6.3 / 2.1 / 7.1 land.
+
+7. ✅ **`InteriorPointerObjectStartTest`** — end-to-end test for the object-start interior-pointer
+   marking bug (see Category B section above). Gated under the *implemented* `InteriorPointers`
+   feature: it fails in the default run by design until the walk bound is fixed.
+8. ✅ **First implemented item**: `WhichGeneration` — the single-generation story: heap object → 0
+   (= `GetMaxGeneration`), non-heap (frozen) → `int.MaxValue` for stock API parity. The only hard
+   EE constraint is consistency of the pair: the EE indexes `GetMaxGeneration + 1`-sized arrays
+   with `WhichGeneration` results (dead-thread GC trigger heuristic, threads.cpp). Nothing in the
+   VM requires MaxGeneration = 2: the remaining consumers are `CollectionCount(maxGen)` (the GC
+   ignores the argument), ETW full-GC tagging, profiler walks, and syncblock scan gates that stay
+   on the full-scan path with `0/0`. `GenerationApiTest` is green on the custom GC and moved to
+   its own implemented feature `GenerationApis`; `ApiSurface` stays pending for `MiscGcApiTest`
+   (`RefreshMemoryLimit`, …).
+
+Validation state: stock GC `--all-features` = 50 passed / 4 skipped (sync-block + the 3 Category B
+tests, which need the custom GC API) / 0 failed; custom GC default = 35 passed / 18 skipped (pending
+features) / **1 failed, exit 1** — `InteriorPointerObjectStartTest`, the confirmed object-start
+marking bug (control scenario passes).
+
+Every test landed green-on-stock; each feature flag flips from "skipped" to "running" on the custom
+GC as the corresponding item in `missing-features.md` is implemented.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -6,9 +6,12 @@ practical. Constraints:
 
 - Every test must run (and pass) on the stock GC — that's what validates the test itself. The only
   exception category is tests that *require* the custom GC API (like the existing sync-block tests).
-- New tests are **feature-gated**: on the custom GC they are skipped unless their feature is opted in,
-  so the suite stays green while features land one by one. On the stock GC the gate is ignored and
-  everything runs.
+- New tests are **feature-gated**: tests of a pending feature are skipped unless opted in with
+  `--feature X` / `--all-features`, so the suite stays green while features land one by one. The gate
+  applies identically on both GCs — a no-arg run means the same thing everywhere, and no GC detection
+  is involved (pending-feature tests are exactly the ones that may fail-fast the custom GC, so a
+  detection misfire would crash the suite instead of skipping). The stock-GC validation run passes
+  `--all-features` explicitly.
 - Scope: .NET 10, win-x64 only. Everything tied to 32-bit (`ALIGN8`), Android (`CROSSREFERENCE` bridge),
   older EEs (async-pinned / sized-ref / weak-native-COM), conservative/interpreter mode is **out of scope**.
 
@@ -56,11 +59,14 @@ class: deadlocked `WaitForPendingFinalizers`, runaway managed loops.
 
 ### 1.3 Subprocess helper
 
-A small helper that re-launches `TestApp.exe --child <TestName>` with extra environment variables and
-asserts on the exit code. Needed for the hard-limit OOM test (env vars must be set before runtime
-startup) and useful later to isolate any test that fail-fasts the process. The child runs the given
-test through the normal runner (`RunSingle` already exists) but with a distinctive exit code protocol
-(e.g. 42 = child scenario succeeded) so a crash is distinguishable from a clean failure.
+`ChildProcess.Run(arguments, extraEnvironment, timeout)` relaunches the current executable with the
+given arguments and environment overrides, inheriting the rest (including `DOTNET_GCName`, so the
+child runs on the same GC), and hands back the exit code and output. There is no generic `--child`
+mode: each subprocess test defines its own marker argument, dispatched at the very top of
+`Program.cs` before any other work so the child scenario fully controls its allocations (it may run
+under a tiny heap hard limit). Currently the only one is `--oom-child`
+(`HeapHardLimitOomTest.ChildArgument`). A distinctive exit-code protocol (42 = child scenario
+succeeded) distinguishes a crash from a clean failure.
 
 ---
 
@@ -272,7 +278,7 @@ feature it belongs to — as the permanent regression guard.
 ## 4. Category C — subprocess tests
 
 ### `HeapHardLimitOOMTest` — feature `HardLimitOom` (doc 1.3)
-Parent spawns `TestApp.exe --child HeapHardLimitOOM` with `DOTNET_GCHeapHardLimit=0x4000000` (64 MB,
+Parent spawns `TestApp.exe --oom-child` with `DOTNET_GCHeapHardLimit=0x8000000` (128 MB,
 env var must precede runtime start — hence subprocess). Child: allocate 1 MB arrays into a list until
 `OutOfMemoryException` is **caught**; verify the heap still works afterwards (drop list, collect,
 allocate); exit 42. Parent asserts exit code 42. Green on stock. For your GC this implies two small

--- a/run-tests.cmd
+++ b/run-tests.cmd
@@ -4,6 +4,7 @@ setlocal enabledelayedexpansion
 REM Default values
 set CONFIG=Release
 set TEST_NAME=
+set EXTRA_ARGS=
 
 REM Parse command-line arguments
 :parse_args
@@ -19,11 +20,24 @@ if /i "%~1"=="--test" (
     shift
     goto parse_args
 )
+if /i "%~1"=="--feature" (
+    set EXTRA_ARGS=!EXTRA_ARGS! --feature %~2
+    shift
+    shift
+    goto parse_args
+)
+if /i "%~1"=="--all-features" (
+    set EXTRA_ARGS=!EXTRA_ARGS! --all-features
+    shift
+    goto parse_args
+)
 echo Unknown argument: %~1
 echo.
-echo Usage: run-tests.cmd [--debug] [--test TEST_NAME]
-echo   --debug      Build TestApp in Debug configuration (default: Release)
-echo   --test NAME  Run only the specified test (case-insensitive)
+echo Usage: run-tests.cmd [--debug] [--test TEST_NAME] [--feature NAME] [--all-features]
+echo   --debug          Build TestApp in Debug configuration (default: Release)
+echo   --test NAME      Run only the specified test (case-insensitive)
+echo   --feature NAME   Run only the tests of that feature, even if pending
+echo   --all-features   Run every test, including pending features
 exit /b 1
 
 :end_parse_args
@@ -71,11 +85,11 @@ echo.
 if not "%TEST_NAME%"=="" (
     echo Running single test: %TEST_NAME%
     echo.
-    .\TestApp\bin\%CONFIG%\net10.0\win-x64\TestApp.exe "%TEST_NAME%"
+    .\TestApp\bin\%CONFIG%\net10.0\win-x64\TestApp.exe "%TEST_NAME%" !EXTRA_ARGS!
 ) else (
     echo Running all tests
     echo.
-    .\TestApp\bin\%CONFIG%\net10.0\win-x64\TestApp.exe
+    .\TestApp\bin\%CONFIG%\net10.0\win-x64\TestApp.exe !EXTRA_ARGS!
 )
 
 set TEST_EXIT_CODE=%ERRORLEVEL%


### PR DESCRIPTION
## What this is

- **`docs/missing-features.md`** — inventory of everything the GC is missing to run any .NET application reliably forever (performance aside; compaction/generations excluded by design).
- **`docs/test-plan.md`** — maps each item to a test, or explains why none is possible.
- **A feature-gated test suite** (54 tests). Every test declares a `GcFeature`; features not implemented yet are listed in `Program.cs` and their tests are skipped unless `--feature X` / `--all-features` is passed. To start working on a feature: remove it from the pending list and watch its tests fail.
- **`ManagedDotnetGC.Api` probe surface** for custom-GC-only tests: `GetContainingObject`/`IsHeapPointer`/`IsPromoted` with sentinel error mapping (no fail-fast while stubs remain), EE bracket-notification counters (with sanctioned `Notify*` call sites for item 2.1), and write-barrier parameter capture.
- **First implemented items**: `WhichGeneration`/`GetMaxGeneration` with the single-generation story (heap object -> 0 = MaxGeneration, non-heap -> int.MaxValue matching stock for frozen objects).
- **A real bug found and fixed**: `ScanRoots` dropped a `GC_CALL_INTERIOR` root landing exactly on an object start (exclusive walk bound made the range `[root, root)` empty). Caught red-first by `InteriorPointerObjectStartTest`, fixed in the second commit, test stays as the regression guard.
- `TransformExportsFile` made idempotent so a failed publish no longer poisons the `.def` in `obj/`.

## Validation

| Run | Result |
|---|---|
| Stock GC, `--all-features` | 50 passed / 4 skipped (require the custom GC API) / 0 failed |
| Custom GC, default (CI mode) | 36 passed / 18 skipped (pending features) / 0 failed, exit 0 |

Green on the stock GC validates the tests themselves; the pending-feature gate keeps the custom GC run green until each feature is picked up.