### PR TITLE
Add a proper README and a CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# ManagedDotnetGC
+
+A .NET garbage collector written in C#, compiled with NativeAOT and loaded into CoreCLR as a standalone GC. Educational project: **non-generational, non-compacting, stop-the-world mark & sweep by design**. The target is the latest version of .NET, on win-x64. 32-bit, ARM, and Android are permanently out of scope.
+
+`docs/missing-features.md` is the roadmap: every known gap against the EE contract, with `runtime-file:line` references into the CoreCLR sources.
+
+## Division of labor
+
+This is an educational project — the point is that the user writes the GC.
+
+- **`ManagedDotnetGC/` (the GC itself): the user writes the code.** Discuss design, investigate, point at runtime sources, review — but do not edit it. Parts may occasionally be delegated, and that will always be stated explicitly.
+- **The tests (`TestApp/`, `ManagedDotnetGC.Tests/`) are managed by the agent**: writing, extending, and fixing tests is your job.
+
+## Development process
+
+- Always commit to a branch, never directly to `master`, and only commit when asked.
+- When the user asks to push, push the branch and open a pull request against `master`.
+
+## Testing strategy
+
+- Whenever possible, a test must run on **both** the official GC and the custom GC. The stock-GC run is what validates that the test asserts real runtime behavior rather than an assumption.
+- `ManagedDotnetGC.Api` (in-process side channel into the GC, obtained through `GC.GetConfigurationVariables()`) extends the range of testable scenarios, but use it **only when there is no other choice**: tests that need it (`RequiresCustomGcApi => true`) are skipped on the stock GC and lose that validation. Anything is game to avoid it, including reflection into runtime internals — `CrossReferenceHandleTest` calling `GCHandle.InternalAlloc` through reflection to create a handle type no public API exposes is the reference example of how far to go.
+- Feature gating: every test declares a `GcFeature`. Unimplemented features are listed in `pendingFeatures` at the top of `TestApp/Program.cs` and their tests are skipped by default, so tests are written ahead of the implementation. The feature ↔ missing-features-item mapping is the *Test gate* column of the TL;DR table in `docs/missing-features.md`. Workflow: remove the enum value from `pendingFeatures`, watch the tests fail, implement.
+
+## Commands
+
+- `run-tests.cmd` — publishes the GC (Debug), builds TestApp, copies the DLL, runs the suite on the custom GC. Forwards `--feature X[,Y]`, `--all-features`, or a single test name (which bypasses the pending gate).
+- Custom GC runs need `DOTNET_GCName=ManagedDotnetGC.dll` and `DOTNET_gcConservative=0`.
+- Stock-GC validation run: build TestApp (`dotnet build .\TestApp -c Release`) and run `TestApp.exe` without `DOTNET_GCName`; use `--all-features` — every test, including pending-feature ones, must pass on the stock GC.
+- Unit tests: `dotnet test .\ManagedDotnetGC.Tests`.
+- CI (`.github/workflows/ci.yml`) runs the unit tests plus the no-argument suite on the custom GC, so the suite must stay green with no arguments.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,68 @@
-Implementation of a custom .NET garbage collector written all in C#.
+# A .NET garbage collector written in C#.
 
-More information on my blog: https://minidump.net/tags/garbage-collection/
+This is an educational project, not meant to evolve into a production-grade GC. The goal is to explore the inner mechanics of the .NET GC by building a new one from scratch.
+
+At the current time, the GC is:
+
+- **Non-generational** — the whole heap is collected every time.
+- **Non-compacting** — objects never move.
+- **Stop-the-world** — mark & sweep runs with the execution engine suspended, no concurrency.
+
+Only the latest version of .NET is supported, and only on Windows x64. The GC is built with NativeAOT and loaded into the CoreCLR runtime as a native library.
+
+**As an educational project, most of the code is written by hand. AI is involved only for writing tests, brainstorming the design, and occasionally writing isolated and well-specified functions.**
+
+## Blog series
+
+The development of this GC is documented on [minidump.net](https://minidump.net/tags/garbage-collection/):
+
+- [Part 1:](https://minidump.net/2025-28-01-writing-a-net-gc-in-c-part-1/) Introduction and setting up the project
+- [Part 2:](https://minidump.net/writing-a-net-gc-in-c-part-2/) Implementing a minimal GC
+- [Part 3:](https://minidump.net/writing-a-net-gc-in-c-part-3/) Using the DAC to inspect the managed objects
+- [Part 4:](https://minidump.net/writing-a-net-gc-in-c-part-4/) Walking the managed heap
+- [Part 5:](https://minidump.net/writing-a-net-gc-in-c-part-5/) Decoding the GCDesc to find the references of a managed object
+- [Part 6:](https://minidump.net/writing-a-net-gc-in-c-part-6/) Implementing the mark and sweep phases
+- [Part 7:](https://minidump.net/writing-a-net-gc-in-c-part-7/) Marking handles
+- [Part 8:](https://minidump.net/writing-a-net-gc-in-c-part-8/) Interior pointers
+- [Part 9:](https://minidump.net/writing-a-net-gc-in-c-part-9/) Frozen segments and new allocation strategy
+- [Part 10:](https://minidump.net/writing-a-net-gc-in-c-part-10/) Finalizers
+
+## Current status
+
+- Loads into .NET and runs real .NET 10 applications on win-x64.
+- Mark & sweep
+- Supports pinned objects implicitly (the memory is never moved so *everything* is pinned)
+- Supports common types of handles, and interior pointers
+- Supports finalization
+- Forward-only: at the moment, the GC isn't capable of reusing memory after freeing an object, so the working set will keep increasing
+
+## Trying it
+
+Requirements: .NET 10 SDK, Windows x64.
+
+```cmd
+publish.cmd     :: builds the GC with NativeAOT and copies it next to TestApp
+launch.cmd      :: runs the test suite against the custom GC
+```
+
+Or `run-tests.cmd` to do all of the above in one go.
+
+To use the GC in your own application, copy the published `ManagedDotnetGC.dll` next to it and set:
+
+```cmd
+set DOTNET_GCName=ManagedDotnetGC.dll
+```
+
+## Repository layout
+
+| Directory | Contents |
+|---|---|
+| `ManagedDotnetGC/` | The GC itself, published as a native library with NativeAOT |
+| `TestApp/` | The behavioral test suite ([details](TestApp/README.md)) |
+| `ManagedDotnetGC.Tests/` | NUnit unit tests for the GC's data structures |
+| `ManagedDotnetGC.Api/` | In-process API to query GC internals from tests |
+| `docs/` | [missing-features.md](docs/missing-features.md), the gap analysis against the EE contract |
+
+## Tests
+
+The test suite is designed to run on both the official GC and this one: the stock-GC run validates that the tests assert real runtime behavior. Tests for features that aren't implemented yet are written ahead of time and feature-gated, so the suite stays green while serving as an executable to-do list — see [TestApp/README.md](TestApp/README.md).


### PR DESCRIPTION
## Summary

- **README.md** — replaces the two-line placeholder with a real presentation of the project: what it is (a C# GC built with NativeAOT and loaded into CoreCLR as a standalone GC) and what it isn't (educational, non-generational, non-compacting, stop-the-world), the full 10-part blog series, a high-level current status, how to try it, and the repository layout. The detailed gap analysis stays in `docs/missing-features.md`.
- **CLAUDE.md** — agent instructions: project scope, division of labor (the user writes the GC code, the agent manages the tests), the testing strategy (run on both GCs whenever possible, `ManagedDotnetGC.Api` only as a last resort), the feature-gating workflow, the development process (always commit to a branch, PR on request), and the useful commands.